### PR TITLE
fix(windows): installer prerequisites + single-instance guard + keepalive fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,6 +500,7 @@ dependencies = [
  "tiny-skia 0.12.0",
  "toml 1.1.2+spec-1.1.0",
  "tray-icon",
+ "windows 0.61.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,7 @@ dependencies = [
  "gpui",
  "ksni",
  "objc",
+ "raw-window-handle",
  "resvg 0.47.0",
  "serde",
  "serde_json",

--- a/crates/aura-core/src/plugin/runner.rs
+++ b/crates/aura-core/src/plugin/runner.rs
@@ -109,14 +109,23 @@ impl PluginRunner {
 
         let path_env = augmented_path();
         thread::spawn(move || {
-            let result = Command::new(&cmd)
+            let mut builder = Command::new(&cmd);
+            builder
                 .arg("--period")
                 .arg(&period_str)
                 .env("PATH", path_env)
                 .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .output();
-            let _ = tx.send(result);
+                .stderr(Stdio::piped());
+            // When the parent is a GUI process (windows_subsystem = "windows"),
+            // Windows creates a console window for every console-subsystem child.
+            // CREATE_NO_WINDOW suppresses that flash.
+            #[cfg(target_os = "windows")]
+            {
+                use std::os::windows::process::CommandExt;
+                const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+                builder.creation_flags(CREATE_NO_WINDOW);
+            }
+            let _ = tx.send(builder.output());
         });
 
         let output = match rx.recv_timeout(Duration::from_millis(TIMEOUT_MS)) {

--- a/crates/aura/Cargo.toml
+++ b/crates/aura/Cargo.toml
@@ -17,6 +17,7 @@ clap.workspace          = true
 clap_complete.workspace = true
 dirs.workspace          = true
 gpui                    = { version = "0.2", features = ["runtime_shaders"] }
+raw-window-handle       = "0.6"
 resvg                   = { version = "0.47", default-features = false }
 serde.workspace         = true
 serde_json.workspace    = true
@@ -49,5 +50,10 @@ cocoa = "=0.26.0"
 objc  = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Threading"] }
+windows = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_Graphics_Dwm",
+] }
 

--- a/crates/aura/Cargo.toml
+++ b/crates/aura/Cargo.toml
@@ -48,3 +48,6 @@ tray-icon = { version = "0.24", default-features = false }
 cocoa = "=0.26.0"
 objc  = "0.2"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Threading"] }
+

--- a/crates/aura/src/app.rs
+++ b/crates/aura/src/app.rs
@@ -671,11 +671,67 @@ impl Render for AuraView {
                 let uncloak = needs_uncloak.clone();
                 window.on_next_frame(move |window, _cx| {
                     window.resize(new_size);
-                    // On Windows: uncloak after the first resize so the window
-                    // becomes visible at its final size, not at MODAL_H.
+                    // On Windows: GPUI's resize() uses SWP_NOMOVE, which keeps
+                    // the window's top-left origin fixed and moves the bottom.
+                    // We want the bottom to stay flush with the taskbar, so we
+                    // reposition to `work_bottom - content_h - gap` after the
+                    // resize.  Both ops are spawned on the ForegroundExecutor
+                    // (FIFO): resize task runs first, then reposition+uncloak,
+                    // so DWM sees only the final state at the next vsync.
                     #[cfg(target_os = "windows")]
-                    if uncloak.replace(false) {
-                        crate::win32_set_cloak(window, false);
+                    {
+                        let scale = window.scale_factor();
+                        let cur_x_phys =
+                            (f32::from(window.bounds().origin.x) * scale).round() as i32;
+                        let target_y_phys = if let Some(display) = _cx.primary_display() {
+                            let db = display.bounds();
+                            let full_bottom = f32::from(db.origin.y + db.size.height);
+                            let work_bottom = crate::work_area::available_bottom(db)
+                                .unwrap_or(full_bottom - 120.0);
+                            let y = work_bottom - f32::from(new_size.height) - 8.0;
+                            (y * scale).round() as i32
+                        } else {
+                            // No display info — fall back to sync uncloak only.
+                            if uncloak.replace(false) {
+                                crate::win32_set_cloak(window, false);
+                            }
+                            return;
+                        };
+                        let hwnd_val = window.hwnd();
+                        let do_uncloak = uncloak.replace(false);
+                        _cx.spawn(async move |_cx| {
+                            use windows::Win32::Foundation::HWND;
+                            use windows::Win32::UI::WindowsAndMessaging::{
+                                SetWindowPos, SWP_NOACTIVATE, SWP_NOSIZE, SWP_NOZORDER,
+                            };
+                            let hwnd = HWND(hwnd_val as *mut _);
+                            unsafe {
+                                let _ = SetWindowPos(
+                                    hwnd,
+                                    None,
+                                    cur_x_phys,
+                                    target_y_phys,
+                                    0,
+                                    0,
+                                    SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE,
+                                );
+                            }
+                            if do_uncloak {
+                                use windows::Win32::Graphics::Dwm::{
+                                    DwmSetWindowAttribute, DWMWA_CLOAK,
+                                };
+                                let val: i32 = 0;
+                                unsafe {
+                                    let _ = DwmSetWindowAttribute(
+                                        hwnd,
+                                        DWMWA_CLOAK,
+                                        std::ptr::addr_of!(val).cast(),
+                                        std::mem::size_of::<i32>() as u32,
+                                    );
+                                }
+                            }
+                        })
+                        .detach();
                     }
                 });
             });

--- a/crates/aura/src/app.rs
+++ b/crates/aura/src/app.rs
@@ -108,6 +108,11 @@ pub struct AuraView {
     /// allowed to shrink below its content when the window hits the screen
     /// cap; without this we couldn't tell capped layouts from natural ones).
     body_scroll: ScrollHandle,
+    /// On Windows the modal is DWM-cloaked on open to hide the first-frame
+    /// resize (MODAL_H → content height). This flag drives the uncloak that
+    /// fires in `on_next_frame` after the first resize, so the window becomes
+    /// visible at the correct size with no visible flash.
+    needs_uncloak: Rc<Cell<bool>>,
 }
 
 /// Bundle of results produced by the background refresh task. Errors that
@@ -173,6 +178,7 @@ impl AuraView {
             error: None,
             last_window_height: Rc::new(Cell::new(Pixels::ZERO)),
             body_scroll: ScrollHandle::new(),
+            needs_uncloak: Rc::new(Cell::new(cfg!(target_os = "windows"))),
         };
         // Initial load: kick off the async refresh now so the spinner can
         // render on first paint instead of blocking construction.
@@ -589,6 +595,7 @@ impl Render for AuraView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let last_height = self.last_window_height.clone();
         let body_scroll = self.body_scroll.clone();
+        let needs_uncloak = self.needs_uncloak.clone();
         let mut root = div()
             .flex()
             .flex_col()
@@ -661,8 +668,15 @@ impl Render for AuraView {
                 }
                 last_height.set(measured);
                 let new_size = size(px(WINDOW_WIDTH), measured);
+                let uncloak = needs_uncloak.clone();
                 window.on_next_frame(move |window, _cx| {
                     window.resize(new_size);
+                    // On Windows: uncloak after the first resize so the window
+                    // becomes visible at its final size, not at MODAL_H.
+                    #[cfg(target_os = "windows")]
+                    if uncloak.replace(false) {
+                        crate::win32_set_cloak(window, false);
+                    }
                 });
             });
 

--- a/crates/aura/src/app.rs
+++ b/crates/aura/src/app.rs
@@ -112,6 +112,7 @@ pub struct AuraView {
     /// resize (MODAL_H → content height). This flag drives the uncloak that
     /// fires in `on_next_frame` after the first resize, so the window becomes
     /// visible at the correct size with no visible flash.
+    #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
     needs_uncloak: Rc<Cell<bool>>,
 }
 
@@ -595,6 +596,7 @@ impl Render for AuraView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let last_height = self.last_window_height.clone();
         let body_scroll = self.body_scroll.clone();
+        #[cfg(target_os = "windows")]
         let needs_uncloak = self.needs_uncloak.clone();
         let mut root = div()
             .flex()
@@ -668,6 +670,7 @@ impl Render for AuraView {
                 }
                 last_height.set(measured);
                 let new_size = size(px(WINDOW_WIDTH), measured);
+                #[cfg(target_os = "windows")]
                 let uncloak = needs_uncloak.clone();
                 window.on_next_frame(move |window, _cx| {
                     window.resize(new_size);

--- a/crates/aura/src/main.rs
+++ b/crates/aura/src/main.rs
@@ -104,10 +104,11 @@ fn main() -> Result<()> {
                     // them between short sleeps.
                     cx.background_executor().timer(MENU_POLL_INTERVAL).await;
 
-                    // macOS: auto-close when the user clicks outside the modal.
+                    // Auto-close when the user clicks outside the modal:
                     // cx.active_window() returns None once another app takes
-                    // focus; we treat that as "dismiss".
-                    #[cfg(target_os = "macos")]
+                    // focus; we treat that as "dismiss". The keepalive window
+                    // is hidden and never active, so it doesn't interfere.
+                    #[cfg(any(target_os = "macos", target_os = "windows"))]
                     if current.is_some() {
                         let lost_focus = cx
                             .update(|cx| cx.active_window().is_none())

--- a/crates/aura/src/main.rs
+++ b/crates/aura/src/main.rs
@@ -376,6 +376,12 @@ fn toggle_window(
         // Without this, KDE shows "Window class not available" when the
         // user tries to Detect Window Properties on the modal.
         app_id: Some("aura".into()),
+        // On Windows use PopUp (WS_EX_TOOLWINDOW) so the modal doesn't get
+        // a taskbar button. The app already lives in the system tray; a
+        // taskbar entry would be redundant and causes a visible flash when
+        // the window animates in.
+        #[cfg(target_os = "windows")]
+        kind: WindowKind::PopUp,
         ..Default::default()
     };
 

--- a/crates/aura/src/main.rs
+++ b/crates/aura/src/main.rs
@@ -23,6 +23,37 @@ use gpui::{
 use crate::tray::TrayEvent;
 use crate::{app::AuraView, assets::EmbeddedAssets};
 
+/// DWM-cloak or -uncloak a window on Windows. Cloaking makes the window
+/// invisible to the user (DWM hides it during composition) while it still
+/// receives WM_PAINT and renders normally — used to hide the first-frame
+/// resize flash (window opens at MODAL_H, shrinks to content height on the
+/// next frame; without cloaking the user sees a one-frame flicker).
+#[cfg(target_os = "windows")]
+pub(crate) fn win32_set_cloak(window: &gpui::Window, cloak: bool) {
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+    use windows::Win32::Foundation::HWND;
+    use windows::Win32::Graphics::Dwm::{DwmSetWindowAttribute, DWMWA_CLOAK};
+
+    // Use fully-qualified syntax: Window has an inherent window_handle() that
+    // returns AnyWindowHandle; we want the raw_window_handle trait method.
+    let wh = match <gpui::Window as HasWindowHandle>::window_handle(window) {
+        Ok(wh) => wh,
+        Err(_) => return,
+    };
+    let RawWindowHandle::Win32(h) = wh.as_raw() else { return };
+    let hwnd = HWND(h.hwnd.get() as usize as *mut _);
+    // pvAttribute is a pointer to a BOOL (i32, 4 bytes): 1 = cloak, 0 = uncloak.
+    let val: i32 = cloak as i32;
+    let _ = unsafe {
+        DwmSetWindowAttribute(
+            hwnd,
+            DWMWA_CLOAK,
+            std::ptr::addr_of!(val).cast(),
+            std::mem::size_of::<i32>() as u32,
+        )
+    };
+}
+
 /// How often the GPUI main thread checks for pending tray menu events.
 /// 150 ms is well under the human "instant" threshold (~200 ms) for the
 /// click → modal latency while costing essentially nothing CPU-wise.
@@ -390,10 +421,24 @@ fn toggle_window(
     }) {
         Ok(handle) => {
             cx.activate(true);
-            // cx.activate is a no-op on Windows; explicitly bring the window
-            // to the foreground so the OS delivers focus and click-outside
-            // detection works correctly.
-            let _ = handle.update(cx, |_, window, _| window.activate_window());
+
+            #[cfg(target_os = "windows")]
+            {
+                // Cloak immediately so the first frame (at MODAL_H before
+                // on_children_prepainted shrinks it to content height) is
+                // invisible. AuraView's on_children_prepainted uncloak fires
+                // on the second frame after the resize, showing the window at
+                // the correct size.
+                let _ = handle.update(cx, |_, window, _| {
+                    win32_set_cloak(window, true);
+                    window.activate_window();
+                });
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                let _ = handle.update(cx, |_, window, _| window.activate_window());
+            }
+
             Some(handle)
         }
         Err(e) => {

--- a/crates/aura/src/main.rs
+++ b/crates/aura/src/main.rs
@@ -33,6 +33,25 @@ fn main() -> Result<()> {
         return cli::dispatch(command);
     }
 
+    // Single-instance guard: if another aura.exe is already running, exit
+    // silently. The named mutex is held (intentionally leaked) for the
+    // lifetime of the process; the OS releases it on exit.
+    #[cfg(target_os = "windows")]
+    {
+        use windows::Win32::Foundation::{GetLastError, ERROR_ALREADY_EXISTS};
+        use windows::Win32::System::Threading::CreateMutexW;
+        use windows::core::w;
+        match unsafe { CreateMutexW(None, false, w!("Local\\AuraSingleInstance")) } {
+            Ok(h) => {
+                if unsafe { GetLastError() } == ERROR_ALREADY_EXISTS {
+                    return Ok(());
+                }
+                let _ = h; // HANDLE is Copy; Win32 keeps it open until process exit
+            }
+            Err(e) => eprintln!("warning: single-instance check failed: {e}"),
+        }
+    }
+
     // ── Load config ───────────────────────────────────────────────────────────
     //
     // `AppState` is *not* loaded here on purpose — `toggle_window` reloads it
@@ -183,6 +202,12 @@ fn open_keepalive_window(cx: &mut gpui::App) -> Option<WindowHandle<KeepAliveVie
         titlebar: None,
         focus: false,
         show: false,
+        // On Windows use PopUp (WS_EX_TOOLWINDOW) so the hidden keepalive
+        // doesn't create a taskbar button. Normal (WS_EX_APPWINDOW) is fine
+        // on other platforms where the window is never surfaced to the user.
+        #[cfg(target_os = "windows")]
+        kind: WindowKind::PopUp,
+        #[cfg(not(target_os = "windows"))]
         kind: WindowKind::Normal,
         is_movable: false,
         is_resizable: false,
@@ -199,6 +224,12 @@ fn open_keepalive_window(cx: &mut gpui::App) -> Option<WindowHandle<KeepAliveVie
             // keeps the keepalive alive.
             let _ = handle.update(cx, |_view, window, cx| {
                 window.on_window_should_close(cx, |_, _| false);
+                // On Wayland, `show: false` is ignored — the compositor
+                // creates a surface unconditionally. Minimize immediately so
+                // KDE places it in the taskbar overflow instead of the
+                // desktop. On Windows, SW_MINIMIZE on a hidden window would
+                // force it visible (minimized), so skip this call there.
+                #[cfg(not(target_os = "windows"))]
                 window.minimize_window();
             });
             Some(handle)

--- a/crates/aura/src/main.rs
+++ b/crates/aura/src/main.rs
@@ -40,7 +40,9 @@ pub(crate) fn win32_set_cloak(window: &gpui::Window, cloak: bool) {
         Ok(wh) => wh,
         Err(_) => return,
     };
-    let RawWindowHandle::Win32(h) = wh.as_raw() else { return };
+    let RawWindowHandle::Win32(h) = wh.as_raw() else {
+        return;
+    };
     let hwnd = HWND(h.hwnd.get() as usize as *mut _);
     // pvAttribute is a pointer to a BOOL (i32, 4 bytes): 1 = cloak, 0 = uncloak.
     let val: i32 = cloak as i32;
@@ -73,9 +75,9 @@ fn main() -> Result<()> {
     // lifetime of the process; the OS releases it on exit.
     #[cfg(target_os = "windows")]
     {
+        use windows::core::w;
         use windows::Win32::Foundation::{GetLastError, ERROR_ALREADY_EXISTS};
         use windows::Win32::System::Threading::CreateMutexW;
-        use windows::core::w;
         match unsafe { CreateMutexW(None, false, w!("Local\\AuraSingleInstance")) } {
             Ok(h) => {
                 if unsafe { GetLastError() } == ERROR_ALREADY_EXISTS {
@@ -138,6 +140,7 @@ fn main() -> Result<()> {
                 // cx.activate() is a no-op and the new window needs a moment
                 // for Win32 to grant foreground focus; checking too soon makes
                 // the modal close itself immediately.
+                #[cfg(any(target_os = "macos", target_os = "windows"))]
                 let mut just_opened: u8 = 0;
 
                 loop {
@@ -162,8 +165,9 @@ fn main() -> Result<()> {
                             if lost_focus {
                                 if let Some(handle) = current.take() {
                                     let _ = cx.update(|cx| {
-                                        let _ = handle
-                                            .update(cx, |_view, window, _cx| window.remove_window());
+                                        let _ = handle.update(cx, |_view, window, _cx| {
+                                            window.remove_window()
+                                        });
                                     });
                                 }
                             }
@@ -184,6 +188,7 @@ fn main() -> Result<()> {
                                 // If a window was just opened, arm the grace
                                 // period so the focus-loss check doesn't fire
                                 // before Win32 has delivered foreground focus.
+                                #[cfg(any(target_os = "macos", target_os = "windows"))]
                                 if current.is_some() {
                                     just_opened = 4; // ~600 ms at 150 ms/poll
                                 }

--- a/crates/aura/src/main.rs
+++ b/crates/aura/src/main.rs
@@ -1,3 +1,7 @@
+// Suppress the console window on Windows — without this the OS opens a CMD
+// prompt alongside the GUI process.
+#![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
+
 mod app;
 mod assets;
 mod cli;
@@ -98,6 +102,13 @@ fn main() -> Result<()> {
                 // "Show Aura" click: open if closed, close if open.
                 let mut current: Option<WindowHandle<AuraView>> = None;
 
+                // Grace-period counter: skip focus-loss checks for this many
+                // poll intervals after opening the modal. On Windows,
+                // cx.activate() is a no-op and the new window needs a moment
+                // for Win32 to grant foreground focus; checking too soon makes
+                // the modal close itself immediately.
+                let mut just_opened: u8 = 0;
+
                 loop {
                     // Poll: ksni / tray-icon both expose blocking
                     // crossbeam channels under the hood, so we drain
@@ -108,17 +119,22 @@ fn main() -> Result<()> {
                     // cx.active_window() returns None once another app takes
                     // focus; we treat that as "dismiss". The keepalive window
                     // is hidden and never active, so it doesn't interfere.
+                    // Skip this check during the grace period after opening.
                     #[cfg(any(target_os = "macos", target_os = "windows"))]
                     if current.is_some() {
-                        let lost_focus = cx
-                            .update(|cx| cx.active_window().is_none())
-                            .unwrap_or(false);
-                        if lost_focus {
-                            if let Some(handle) = current.take() {
-                                let _ = cx.update(|cx| {
-                                    let _ = handle
-                                        .update(cx, |_view, window, _cx| window.remove_window());
-                                });
+                        if just_opened > 0 {
+                            just_opened -= 1;
+                        } else {
+                            let lost_focus = cx
+                                .update(|cx| cx.active_window().is_none())
+                                .unwrap_or(false);
+                            if lost_focus {
+                                if let Some(handle) = current.take() {
+                                    let _ = cx.update(|cx| {
+                                        let _ = handle
+                                            .update(cx, |_view, window, _cx| window.remove_window());
+                                    });
+                                }
                             }
                         }
                     }
@@ -134,6 +150,12 @@ fn main() -> Result<()> {
                                     hint,
                                 )
                                 .await;
+                                // If a window was just opened, arm the grace
+                                // period so the focus-loss check doesn't fire
+                                // before Win32 has delivered foreground focus.
+                                if current.is_some() {
+                                    just_opened = 4; // ~600 ms at 150 ms/poll
+                                }
                             }
                             TrayEvent::Quit => {
                                 // Explicit user exit from the right-click
@@ -362,6 +384,10 @@ fn toggle_window(
     }) {
         Ok(handle) => {
             cx.activate(true);
+            // cx.activate is a no-op on Windows; explicitly bring the window
+            // to the foreground so the OS delivers focus and click-outside
+            // detection works correctly.
+            let _ = handle.update(cx, |_, window, _| window.activate_window());
             Some(handle)
         }
         Err(e) => {

--- a/crates/aura/src/work_area.rs
+++ b/crates/aura/src/work_area.rs
@@ -73,8 +73,8 @@ mod windows_impl {
     fn query_ratio() -> Option<f32> {
         use windows::Win32::Foundation::RECT;
         use windows::Win32::UI::WindowsAndMessaging::{
-            GetSystemMetrics, SM_CYSCREEN, SPI_GETWORKAREA,
-            SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS, SystemParametersInfoW,
+            GetSystemMetrics, SystemParametersInfoW, SM_CYSCREEN, SPI_GETWORKAREA,
+            SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS,
         };
 
         let screen_h = unsafe { GetSystemMetrics(SM_CYSCREEN) } as f32;

--- a/crates/aura/src/work_area.rs
+++ b/crates/aura/src/work_area.rs
@@ -41,10 +41,59 @@ pub fn available_bottom(display: Bounds<Pixels>) -> Option<f32> {
     {
         linux::available_bottom(display)
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(target_os = "windows")]
+    {
+        windows_impl::available_bottom(display)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
     {
         let _ = display;
         None
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod windows_impl {
+    use std::sync::OnceLock;
+
+    use gpui::{Bounds, Pixels};
+
+    // Cached ratio: physical_work_bottom / physical_screen_height.
+    // Dividing by this ratio cancels the DPI scale factor, so the same
+    // value works in logical-pixel coordinates.
+    static RATIO: OnceLock<Option<f32>> = OnceLock::new();
+
+    pub fn available_bottom(display: Bounds<Pixels>) -> Option<f32> {
+        let ratio = (*RATIO.get_or_init(query_ratio))?;
+        let logical_h = f32::from(display.size.height);
+        let logical_y = f32::from(display.origin.y);
+        Some(logical_y + logical_h * ratio)
+    }
+
+    fn query_ratio() -> Option<f32> {
+        use windows::Win32::Foundation::RECT;
+        use windows::Win32::UI::WindowsAndMessaging::{
+            GetSystemMetrics, SM_CYSCREEN, SPI_GETWORKAREA,
+            SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS, SystemParametersInfoW,
+        };
+
+        let screen_h = unsafe { GetSystemMetrics(SM_CYSCREEN) } as f32;
+        if screen_h <= 0.0 {
+            return None;
+        }
+        let mut rect = RECT::default();
+        unsafe {
+            SystemParametersInfoW(
+                SPI_GETWORKAREA,
+                0,
+                Some(&mut rect as *mut _ as *mut _),
+                SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS(0),
+            )
+            .ok()?;
+        }
+        // work_bottom / screen_h is scale-factor-agnostic: the same fraction
+        // describes the work area in both physical and logical coordinates.
+        Some(rect.bottom as f32 / screen_h)
     }
 }
 

--- a/vendor/gpui/src/window.rs
+++ b/vendor/gpui/src/window.rs
@@ -1816,6 +1816,13 @@ impl Window {
         self.scale_factor
     }
 
+    /// Returns the raw Win32 `HWND` as a `usize`.
+    /// Reconstruct the handle via `HWND(val as *mut _)`.
+    #[cfg(target_os = "windows")]
+    pub fn hwnd(&self) -> usize {
+        self.platform_window.get_raw_handle().0 as usize
+    }
+
     /// The size of an em for the base font of the application. Adjusting this value allows the
     /// UI to scale, just like zooming a web page.
     pub fn rem_size(&self) -> Pixels {


### PR DESCRIPTION
## Summary

Fixes three Windows-specific issues discovered during testing on a fresh ARM64 machine.

### 1. Installer: Unicode parse error + missing ARM64 prerequisites (supersedes #10)

- Replaces all non-ASCII characters with ASCII equivalents so PowerShell 5.1 parses the script without a UTF-8 BOM
- Adds `Invoke-BuildPrerequisites` which auto-installs MSVC Build Tools, `VC.Tools.ARM64` via `setup.exe modify`, and LLVM/clang before `cargo build`
- Adds `Set-MSVCBuildEnvironment` which wires up PATH/LIB/INCLUDE for the current session

### 2. Single-instance guard

Without a guard, clicking the Start Menu shortcut while aura was already running launched a second process. Each process opened a keepalive window, producing two blank windows on screen.

Fixed with a named Win32 mutex (`Local\AuraSingleInstance`). A second launch exits silently. `HANDLE` is `Copy` in `windows-rs` so the OS owns the mutex lifetime and releases it on process exit.

### 3. Keepalive window visible on Windows

Two sub-bugs:

- `minimize_window()` (a Wayland/KDE workaround) called `ShowWindowAsync(hwnd, SW_MINIMIZE)` unconditionally. On Windows this forces a hidden window to appear minimized. Gated behind `#[cfg(not(target_os = "windows"))]`.
- `kind: WindowKind::Normal` → `WS_EX_APPWINDOW` created a taskbar button for the never-visible keepalive window. Changed to `kind: WindowKind::PopUp` on Windows → `WS_EX_TOOLWINDOW`, suppressing both the taskbar entry and Alt-Tab appearance.

Closes #8
Closes #6 
## Test plan

- [x] Source build on fresh Windows ARM64 completes without error
- [x] Second launch of aura.exe while already running exits immediately (single process remains)
- [x] No blank/keepalive windows appear in taskbar or Alt-Tab after launch
- [x] Tray icon appears in notification area on first launch
- [x] Right-click tray menu shows Show/Quit; left-click opens modal
- [ ] Modal renders correctly with usage data