### PR TITLE
feat/cross platform integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,6 +493,7 @@ dependencies = [
  "dirs 6.0.0",
  "gpui",
  "ksni",
+ "libc",
  "objc",
  "raw-window-handle",
  "resvg 0.47.0",

--- a/crates/aura-core/src/config.rs
+++ b/crates/aura-core/src/config.rs
@@ -97,7 +97,15 @@ pub struct DisplayConfig {
     /// case-insensitive.
     #[serde(default)]
     pub plugin_order: Vec<String>,
-    /// macOS: appear in Cmd+Tab app switcher. Default false (background-only).
+    /// Whether the modal appears in the OS's "where are my windows"
+    /// surfaces — Cmd+Tab + Dock on macOS, Alt+Tab + taskbar on Windows,
+    /// panel + window switcher on Linux. Default `false` so Aura behaves
+    /// like a true tray-indicator (the icon by the clock is the entire
+    /// UI surface). Set `true` if you want to alt-tab to the modal.
+    ///
+    /// On macOS this also drives the process-wide NSApplication
+    /// activation policy (Accessory vs Regular); on Windows / Linux it
+    /// only affects the modal's window kind, picked at open time.
     pub show_in_app_switcher: bool,
     /// Auto-close the modal when it loses focus (click outside, switch app).
     /// Default true — matches typical menu-bar / tray-popup behaviour.

--- a/crates/aura-core/src/config.rs
+++ b/crates/aura-core/src/config.rs
@@ -99,6 +99,12 @@ pub struct DisplayConfig {
     pub plugin_order: Vec<String>,
     /// macOS: appear in Cmd+Tab app switcher. Default false (background-only).
     pub show_in_app_switcher: bool,
+    /// Auto-close the modal when it loses focus (click outside, switch app).
+    /// Default true — matches typical menu-bar / tray-popup behaviour.
+    /// Set to false if you'd rather the modal stay open until you click the
+    /// tray icon again (useful when copy-pasting from the modal into
+    /// another window).
+    pub dismiss_on_focus_loss: bool,
 }
 
 impl Default for DisplayConfig {
@@ -108,6 +114,7 @@ impl Default for DisplayConfig {
             anchor: "auto".to_string(),
             plugin_order: Vec::new(),
             show_in_app_switcher: false,
+            dismiss_on_focus_loss: true,
         }
     }
 }

--- a/crates/aura/Cargo.toml
+++ b/crates/aura/Cargo.toml
@@ -45,6 +45,10 @@ ksni = { version = "0.3", default-features = false, features = ["blocking", "asy
 [target.'cfg(not(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd")))'.dependencies]
 tray-icon = { version = "0.24", default-features = false }
 
+[target.'cfg(unix)'.dependencies]
+# flock-based single-instance guard. See `platform::acquire_single_instance`.
+libc = "0.2"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "=0.26.0"
 objc  = "0.2"
@@ -55,5 +59,6 @@ windows = { version = "0.61", features = [
     "Win32_System_Threading",
     "Win32_UI_WindowsAndMessaging",
     "Win32_Graphics_Dwm",
+    "Win32_UI_Shell",
 ] }
 

--- a/crates/aura/src/app.rs
+++ b/crates/aura/src/app.rs
@@ -223,6 +223,10 @@ impl AuraView {
     /// Apply a `RefreshResult` back to the view on the foreground thread.
     fn apply_refresh_result(&mut self, result: RefreshResult, cx: &mut Context<Self>) {
         if let Some(cfg) = result.config {
+            // Push shared-config fields out to the tray loop so its
+            // focus-loss check picks up the new dismiss_on_focus_loss
+            // value on the next poll without a service restart.
+            crate::runtime::set_from_config(&cfg);
             self.config = cfg;
         }
         if let Some(theme) = result.theme {

--- a/crates/aura/src/app.rs
+++ b/crates/aura/src/app.rs
@@ -422,35 +422,12 @@ impl AuraView {
         self.open_in_editor(&self.theme_path.clone(), cx);
     }
 
-    fn open_in_editor(&mut self, path: &std::path::Path, cx: &mut Context<Self>) {
-        use std::process::{Command, Stdio};
-
-        // macOS: `open` is the native file-opener (xdg-open doesn't exist).
-        // Linux/BSD: try xdg-open.
-        // Fallback on all platforms: $EDITOR.
-        #[cfg(target_os = "macos")]
-        let opener = "open";
-        #[cfg(not(target_os = "macos"))]
-        let opener = "xdg-open";
-
-        let spawned = Command::new(opener)
-            .arg(path)
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn();
-
-        if spawned.is_err() {
-            if let Ok(editor) = std::env::var("EDITOR") {
-                let _ = Command::new(editor).arg(path).spawn();
-            } else {
-                self.error = Some(format!(
-                    "Could not open editor (`{opener}` failed and `$EDITOR` unset). \
-                     Edit {} manually.",
-                    path.display()
-                ));
-                cx.notify();
-            }
-        }
+    fn open_in_editor(&mut self, path: &std::path::Path, _cx: &mut Context<Self>) {
+        // `platform::open_path` invokes the OS default handler (xdg-open /
+        // open / ShellExecuteW) and, on failure, falls back to revealing the
+        // file in the system file manager. We never block the UI on the
+        // spawn — both the open and the fallback happen on a detached thread.
+        crate::platform::open_path(path);
     }
 
     fn set_profile(&mut self, name: String, cx: &mut Context<Self>) {
@@ -2094,12 +2071,7 @@ const GITHUB_ISSUES_URL: &str = "https://github.com/Rfluid/aura/issues";
 const SPONSOR_URL: &str = "https://github.com/Rfluid/aura/blob/main/SPONSOR.md";
 
 fn open_url(url: &str) {
-    use std::process::{Command, Stdio};
-    let _ = Command::new("xdg-open")
-        .arg(url)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn();
+    crate::platform::open_url(url);
 }
 
 // ── Helpers: icons, buttons, color math ──────────────────────────────────────

--- a/crates/aura/src/app.rs
+++ b/crates/aura/src/app.rs
@@ -504,17 +504,6 @@ impl AuraView {
         cx.notify();
     }
 
-    #[cfg(target_os = "macos")]
-    fn toggle_app_switcher(&mut self, cx: &mut Context<Self>) {
-        self.config.display.show_in_app_switcher = !self.config.display.show_in_app_switcher;
-        let show = self.config.display.show_in_app_switcher;
-        if let Err(e) = self.config.save(&self.config_path) {
-            self.error = Some(format!("Could not save settings: {e}"));
-        }
-        crate::platform::apply_app_switcher_policy(show);
-        cx.notify();
-    }
-
     fn current_agent(&self) -> Option<&AgentConfig> {
         self.config
             .agents
@@ -1939,65 +1928,6 @@ impl AuraView {
             .border_1()
             .border_color(rgb(self.theme.colors.border))
             .on_click(cx.listener(|_, _: &ClickEvent, _, _| {}));
-
-        // ── macOS: Show in App Switcher toggle ───────────────────────────────
-        #[cfg(target_os = "macos")]
-        {
-            let enabled = self.config.display.show_in_app_switcher;
-            let (pill_bg, knob_x) = if enabled {
-                (self.theme.colors.accent, gpui::px(14.0))
-            } else {
-                (self.theme.colors.border, gpui::px(2.0))
-            };
-            let toggle_pill = div()
-                .id("toggle-pill")
-                .w(gpui::px(32.0))
-                .h(gpui::px(18.0))
-                .rounded_full()
-                .bg(rgb(pill_bg))
-                .flex()
-                .items_center()
-                .relative()
-                .child(
-                    div()
-                        .absolute()
-                        .left(knob_x)
-                        .w(gpui::px(14.0))
-                        .h(gpui::px(14.0))
-                        .rounded_full()
-                        .bg(rgb(self.theme.colors.text)),
-                )
-                .on_click(cx.listener(|view, _: &ClickEvent, _, cx| {
-                    view.toggle_app_switcher(cx);
-                }));
-
-            card = card.child(
-                div()
-                    .flex()
-                    .flex_row()
-                    .items_center()
-                    .justify_between()
-                    .px_2()
-                    .py_2()
-                    .rounded_md()
-                    .text_xs()
-                    .text_color(rgb(self.theme.colors.text))
-                    .child(
-                        div()
-                            .flex()
-                            .flex_row()
-                            .items_center()
-                            .gap_2()
-                            .child(svg_icon(
-                                "icons/sliders.svg",
-                                self.theme.colors.text_dim,
-                                14.0,
-                            ))
-                            .child("Show in App Switcher"),
-                    )
-                    .child(toggle_pill),
-            );
-        }
 
         let text = self.theme.colors.text;
         let text_dim = self.theme.colors.text_dim;

--- a/crates/aura/src/app.rs
+++ b/crates/aura/src/app.rs
@@ -1856,12 +1856,6 @@ impl AuraView {
     fn render_more_modal(&self, cx: &mut Context<Self>) -> AnyElement {
         let items = [
             (
-                "modal-themes",
-                "icons/sliders.svg",
-                "Themes",
-                ModalAction::Themes,
-            ),
-            (
                 "modal-updates",
                 "icons/download.svg",
                 "Check updates",
@@ -2024,6 +2018,10 @@ impl AuraView {
             );
         }
 
+        let text = self.theme.colors.text;
+        let text_dim = self.theme.colors.text_dim;
+        let surface_hi = self.theme.colors.surface_hi;
+
         // ── Open config file ─────────────────────────────────────────────────
         card = card.child(
             div()
@@ -2036,16 +2034,34 @@ impl AuraView {
                 .py_2()
                 .rounded_md()
                 .text_xs()
-                .text_color(rgb(self.theme.colors.text))
-                .hover(|d| d.bg(rgb(self.theme.colors.surface_hi)))
-                .child(svg_icon(
-                    "icons/arrow_up_right.svg",
-                    self.theme.colors.text_dim,
-                    14.0,
-                ))
+                .text_color(rgb(text))
+                .hover(move |d| d.bg(rgb(surface_hi)))
+                .child(svg_icon("icons/arrow_up_right.svg", text_dim, 14.0))
                 .child("Open config file")
                 .on_click(cx.listener(|view, _: &ClickEvent, _, cx| {
                     view.open_config(cx);
+                    view.close_settings_panel(cx);
+                })),
+        );
+
+        // ── Themes ───────────────────────────────────────────────────────────
+        card = card.child(
+            div()
+                .id("settings-themes")
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap_2()
+                .px_2()
+                .py_2()
+                .rounded_md()
+                .text_xs()
+                .text_color(rgb(text))
+                .hover(move |d| d.bg(rgb(surface_hi)))
+                .child(svg_icon("icons/sliders.svg", text_dim, 14.0))
+                .child("Themes")
+                .on_click(cx.listener(|view, _: &ClickEvent, _, cx| {
+                    view.open_theme(cx);
                     view.close_settings_panel(cx);
                 })),
         );
@@ -2055,7 +2071,6 @@ impl AuraView {
 
     fn handle_modal_action(&mut self, action: ModalAction, cx: &mut Context<Self>) {
         match action {
-            ModalAction::Themes => self.open_theme(cx),
             ModalAction::Updates => open_url(GITHUB_RELEASES_URL),
             ModalAction::Sponsor => open_url(SPONSOR_URL),
             ModalAction::Github => open_url(GITHUB_REPO_URL),
@@ -2067,7 +2082,6 @@ impl AuraView {
 
 #[derive(Debug, Clone, Copy)]
 enum ModalAction {
-    Themes,
     Updates,
     Sponsor,
     Github,

--- a/crates/aura/src/main.rs
+++ b/crates/aura/src/main.rs
@@ -139,8 +139,9 @@ fn main() -> Result<()> {
                 // poll intervals after opening the modal. On Windows,
                 // cx.activate() is a no-op and the new window needs a moment
                 // for Win32 to grant foreground focus; checking too soon makes
-                // the modal close itself immediately.
-                #[cfg(any(target_os = "macos", target_os = "windows"))]
+                // the modal close itself immediately. The same race shows up
+                // on Wayland compositors that defer focus events until the
+                // surface has been mapped and committed.
                 let mut just_opened: u8 = 0;
 
                 loop {
@@ -154,7 +155,6 @@ fn main() -> Result<()> {
                     // focus; we treat that as "dismiss". The keepalive window
                     // is hidden and never active, so it doesn't interfere.
                     // Skip this check during the grace period after opening.
-                    #[cfg(any(target_os = "macos", target_os = "windows"))]
                     if current.is_some() {
                         if just_opened > 0 {
                             just_opened -= 1;
@@ -187,8 +187,7 @@ fn main() -> Result<()> {
                                 .await;
                                 // If a window was just opened, arm the grace
                                 // period so the focus-loss check doesn't fire
-                                // before Win32 has delivered foreground focus.
-                                #[cfg(any(target_os = "macos", target_os = "windows"))]
+                                // before the OS has delivered foreground focus.
                                 if current.is_some() {
                                     just_opened = 4; // ~600 ms at 150 ms/poll
                                 }

--- a/crates/aura/src/main.rs
+++ b/crates/aura/src/main.rs
@@ -70,23 +70,12 @@ fn main() -> Result<()> {
         return cli::dispatch(command);
     }
 
-    // Single-instance guard: if another aura.exe is already running, exit
-    // silently. The named mutex is held (intentionally leaked) for the
-    // lifetime of the process; the OS releases it on exit.
-    #[cfg(target_os = "windows")]
-    {
-        use windows::core::w;
-        use windows::Win32::Foundation::{GetLastError, ERROR_ALREADY_EXISTS};
-        use windows::Win32::System::Threading::CreateMutexW;
-        match unsafe { CreateMutexW(None, false, w!("Local\\AuraSingleInstance")) } {
-            Ok(h) => {
-                if unsafe { GetLastError() } == ERROR_ALREADY_EXISTS {
-                    return Ok(());
-                }
-                let _ = h; // HANDLE is Copy; Win32 keeps it open until process exit
-            }
-            Err(e) => eprintln!("warning: single-instance check failed: {e}"),
-        }
+    // Single-instance guard: if another Aura is already running, exit
+    // silently — the running tray icon will service the next click. The
+    // lock is held (intentionally leaked) for the lifetime of the process;
+    // the OS releases it on exit. See `platform::acquire_single_instance`.
+    if !platform::acquire_single_instance() {
+        return Ok(());
     }
 
     // ── Load config ───────────────────────────────────────────────────────────

--- a/crates/aura/src/main.rs
+++ b/crates/aura/src/main.rs
@@ -114,11 +114,13 @@ fn main() -> Result<()> {
     Application::new()
         .with_assets(EmbeddedAssets)
         .run(move |cx| {
-            // Switch to Accessory policy (no Dock icon / no Cmd+Tab) unless
-            // the user has explicitly opted in to regular app-switcher appearance.
-            // Must run after GPUI's did_finish_launching (which forces Regular)
-            // so this fires inside the run callback, not before it.
-            platform::apply_app_switcher_policy(config.display.show_in_app_switcher);
+            // GPUI forces NSApplicationActivationPolicyRegular in
+            // did_finish_launching; reapply the user's preference here so it
+            // sticks. `runtime::set_from_config` (called at startup before
+            // .run) only fires once, *before* GPUI launches — without this
+            // second push, the user's Accessory choice would be overwritten
+            // by the time we hit the run closure on macOS.
+            platform::apply_app_switcher_policy(runtime::show_in_app_switcher());
 
             // Hold the handle in the move-closure so it isn't dropped.
             let _keepalive = open_keepalive_window(cx);
@@ -420,6 +422,25 @@ fn toggle_window(
     });
 
     let bounds = compute_modal_bounds(cx, hint);
+    // `display.show_in_app_switcher` controls whether the modal appears in
+    // the OS's "where are my windows" surfaces — Cmd+Tab + Dock on macOS,
+    // Alt+Tab + taskbar on Windows, panel + window switcher on Linux. The
+    // process-wide macOS NSApp policy is applied separately at startup and
+    // on each refresh (see `platform::apply_app_switcher_policy`).
+    //
+    // - true  → WindowKind::Normal: regular app window (WS_EX_APPWINDOW on
+    //           Windows; default xdg_toplevel on Wayland). Visible in the
+    //           switcher.
+    // - false → WindowKind::PopUp: WS_EX_TOOLWINDOW on Windows, no taskbar
+    //           entry on most Linux DEs. The visible flash from the
+    //           taskbar animation goes away in this mode, which is the
+    //           reason we kept it the hard-coded default on Windows
+    //           historically.
+    let kind = if config.display.show_in_app_switcher {
+        WindowKind::Normal
+    } else {
+        WindowKind::PopUp
+    };
     let opts = WindowOptions {
         window_bounds: Some(WindowBounds::Windowed(bounds)),
         titlebar: None,
@@ -428,12 +449,7 @@ fn toggle_window(
         // Without this, KDE shows "Window class not available" when the
         // user tries to Detect Window Properties on the modal.
         app_id: Some("aura".into()),
-        // On Windows use PopUp (WS_EX_TOOLWINDOW) so the modal doesn't get
-        // a taskbar button. The app already lives in the system tray; a
-        // taskbar entry would be redundant and causes a visible flash when
-        // the window animates in.
-        #[cfg(target_os = "windows")]
-        kind: WindowKind::PopUp,
+        kind,
         ..Default::default()
     };
 

--- a/crates/aura/src/main.rs
+++ b/crates/aura/src/main.rs
@@ -119,6 +119,7 @@ fn main() -> Result<()> {
             let config = config.clone();
             let config_path = config_path.clone();
 
+            let dismiss_on_focus_loss = config.display.dismiss_on_focus_loss;
             cx.spawn(async move |cx| {
                 // The currently-open window, if any. We toggle on each
                 // "Show Aura" click: open if closed, close if open.
@@ -143,8 +144,10 @@ fn main() -> Result<()> {
                     // cx.active_window() returns None once another app takes
                     // focus; we treat that as "dismiss". The keepalive window
                     // is hidden and never active, so it doesn't interfere.
-                    // Skip this check during the grace period after opening.
-                    if current.is_some() {
+                    // Skip this check during the grace period after opening,
+                    // and skip it entirely when the user has opted out via
+                    // display.dismiss_on_focus_loss=false.
+                    if dismiss_on_focus_loss && current.is_some() {
                         if just_opened > 0 {
                             just_opened -= 1;
                         } else {

--- a/crates/aura/src/main.rs
+++ b/crates/aura/src/main.rs
@@ -7,6 +7,7 @@ mod assets;
 mod cli;
 mod format;
 mod platform;
+mod runtime;
 mod tray;
 mod work_area;
 
@@ -82,10 +83,16 @@ fn main() -> Result<()> {
     //
     // `AppState` is *not* loaded here on purpose — `toggle_window` reloads it
     // from disk each time the modal opens, so a profile change made in one
-    // session is visible the next time the user clicks the tray icon. Loading
-    // it once at startup would cache a stale snapshot in the closure below.
+    // session is visible the next time the user clicks the tray icon.
+    //
+    // `AppConfig` is also reloaded on every tray click (see the `Show` arm
+    // below) and on every Refresh-button click (see `app::do_refresh`).
+    // The shared `runtime` module mirrors a handful of `[display]` fields
+    // into atomics so both reload paths keep `main`'s tray loop in sync
+    // with the modal view.
     let config_path = AppConfig::default_path();
     let config = AppConfig::load_with_discovery(&config_path)?;
+    runtime::set_from_config(&config);
 
     // ── Install tray icon (best-effort: warn on failure but keep going) ───────
     let _tray = match tray::install() {
@@ -119,7 +126,6 @@ fn main() -> Result<()> {
             let config = config.clone();
             let config_path = config_path.clone();
 
-            let dismiss_on_focus_loss = config.display.dismiss_on_focus_loss;
             cx.spawn(async move |cx| {
                 // The currently-open window, if any. We toggle on each
                 // "Show Aura" click: open if closed, close if open.
@@ -146,8 +152,11 @@ fn main() -> Result<()> {
                     // is hidden and never active, so it doesn't interfere.
                     // Skip this check during the grace period after opening,
                     // and skip it entirely when the user has opted out via
-                    // display.dismiss_on_focus_loss=false.
-                    if dismiss_on_focus_loss && current.is_some() {
+                    // display.dismiss_on_focus_loss=false. The flag is read
+                    // from `runtime::dismiss_on_focus_loss()` on every poll
+                    // so a refresh-button click or a tray-click reload picks
+                    // up the new value without a service restart.
+                    if runtime::dismiss_on_focus_loss() && current.is_some() {
                         if just_opened > 0 {
                             just_opened -= 1;
                         } else {
@@ -169,10 +178,26 @@ fn main() -> Result<()> {
                     while let Some(event) = tray::try_recv_event() {
                         match event {
                             TrayEvent::Show { hint } => {
+                                // Reload AppConfig from disk so edits made
+                                // since the last open (whether via the
+                                // settings panel, an external editor, or
+                                // `aura plugin add`) take effect on this
+                                // open. Fall back to the startup snapshot
+                                // if the reload fails so a transient I/O
+                                // error doesn't break the toggle.
+                                let fresh_config =
+                                    AppConfig::load_with_discovery(&config_path)
+                                        .unwrap_or_else(|e| {
+                                            eprintln!(
+                                                "aura: config reload failed ({e}); using cached snapshot"
+                                            );
+                                            config.clone()
+                                        });
+                                runtime::set_from_config(&fresh_config);
                                 current = toggle(
                                     cx,
                                     current.take(),
-                                    config.clone(),
+                                    fresh_config,
                                     config_path.clone(),
                                     hint,
                                 )

--- a/crates/aura/src/platform.rs
+++ b/crates/aura/src/platform.rs
@@ -1,3 +1,26 @@
+//! Thin per-OS façade for the things Aura asks of the host: tweaking the
+//! macOS activation policy and asking the desktop to open a file/URL with
+//! the user's default handler.
+//!
+//! The `open_*` functions return immediately and do the actual work on a
+//! detached thread — the click handlers that call them run on the GPUI
+//! main thread and shouldn't block on a subprocess.
+//!
+//! ## Fallback semantics
+//!
+//! `open_path()` first tries the OS default handler (`xdg-open` / `open` /
+//! `ShellExecuteW`). If that handler reports failure — common on Linux when
+//! the MIME type has no association, or on Windows when a path has no
+//! registered verb — it falls back to revealing the path in the system file
+//! manager (`org.freedesktop.FileManager1.ShowItems` over D-Bus on Linux,
+//! `open -R` on macOS, `explorer /select,` on Windows). That way a
+//! freshly-installed system without a TOML editor still lands the user
+//! somewhere they can act on the file, instead of a silent no-op.
+
+use std::path::Path;
+
+// ── macOS activation policy ──────────────────────────────────────────────────
+
 /// Set the macOS NSApplication activation policy.
 ///
 /// `show = true`  → NSApplicationActivationPolicyRegular   (appears in Cmd+Tab)
@@ -22,3 +45,196 @@ pub fn apply_app_switcher_policy(show: bool) {
 
 #[cfg(not(target_os = "macos"))]
 pub fn apply_app_switcher_policy(_show: bool) {}
+
+// ── Open with system handler (file or URL) ──────────────────────────────────
+
+/// Open a filesystem path with the desktop's default handler, falling back to
+/// the file manager (with the file pre-selected when supported) if no handler
+/// is registered.
+pub fn open_path(path: &Path) {
+    let path = path.to_path_buf();
+    std::thread::Builder::new()
+        .name("aura-open-path".into())
+        .spawn(move || {
+            if let Err(e) = open_path_blocking(&path) {
+                eprintln!(
+                    "aura: open_path({}) failed ({e}); falling back to file manager",
+                    path.display()
+                );
+                if let Err(e2) = reveal_in_file_manager_blocking(&path) {
+                    eprintln!(
+                        "aura: reveal_in_file_manager({}) also failed: {e2}",
+                        path.display()
+                    );
+                }
+            }
+        })
+        .ok();
+}
+
+/// Open a URL with the desktop's default browser. Unlike `open_path`, there is
+/// no file-manager fallback — if the browser launch fails we just log.
+pub fn open_url(url: &str) {
+    let url = url.to_owned();
+    std::thread::Builder::new()
+        .name("aura-open-url".into())
+        .spawn(move || {
+            if let Err(e) = open_url_blocking(&url) {
+                eprintln!("aura: open_url({url}) failed: {e}");
+            }
+        })
+        .ok();
+}
+
+// ── Per-OS blocking impls ────────────────────────────────────────────────────
+
+fn open_path_blocking(path: &Path) -> std::io::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        run_status("open", &[path.as_os_str()])
+    }
+    #[cfg(target_os = "windows")]
+    {
+        shell_execute_open(path)
+    }
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    {
+        run_status("xdg-open", &[path.as_os_str()])
+    }
+}
+
+fn open_url_blocking(url: &str) -> std::io::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        run_status("open", &[std::ffi::OsStr::new(url)])
+    }
+    #[cfg(target_os = "windows")]
+    {
+        shell_execute_open(Path::new(url))
+    }
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    {
+        run_status("xdg-open", &[std::ffi::OsStr::new(url)])
+    }
+}
+
+fn reveal_in_file_manager_blocking(path: &Path) -> std::io::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        // `open -R` highlights the target in Finder rather than opening it.
+        run_status("open", &[std::ffi::OsStr::new("-R"), path.as_os_str()])
+    }
+    #[cfg(target_os = "windows")]
+    {
+        // `explorer /select,<path>` opens Explorer with the file selected.
+        // explorer.exe always returns exit code 1 on success; treat any
+        // spawn that *runs* as success.
+        let _ = std::process::Command::new("explorer.exe")
+            .arg(format!("/select,{}", path.display()))
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()?
+            .wait()?;
+        Ok(())
+    }
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    {
+        linux_reveal(path)
+    }
+}
+
+// Generic Command::status helper that maps non-success exit codes to an Err
+// so callers can detect "no handler registered for this MIME type" the way
+// `xdg-open` reports it (exit code 3).
+#[cfg(not(target_os = "windows"))]
+fn run_status(program: &str, args: &[&std::ffi::OsStr]) -> std::io::Result<()> {
+    let status = std::process::Command::new(program)
+        .args(args)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(format!(
+            "{program} exited with {status}"
+        )))
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn shell_execute_open(path: &Path) -> std::io::Result<()> {
+    use windows::core::{w, HSTRING};
+    use windows::Win32::UI::Shell::ShellExecuteW;
+    use windows::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
+
+    let target = HSTRING::from(path);
+    let ret = unsafe { ShellExecuteW(None, w!("open"), &target, None, None, SW_SHOWNORMAL) };
+    // Per the MSDN docs, return values ≤32 are error codes; anything larger
+    // is the handle of the launched application/document.
+    if ret.0 as isize > 32 {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(format!(
+            "ShellExecuteW returned {}",
+            ret.0 as isize
+        )))
+    }
+}
+
+// ── Linux file manager reveal ───────────────────────────────────────────────
+//
+// The org.freedesktop.FileManager1 D-Bus interface is implemented by GNOME
+// Files (Nautilus), KDE Dolphin, Cinnamon Nemo, MATE Caja, and Pantheon
+// Files — i.e. the file manager that ships with every mainstream desktop.
+// We shell out to `dbus-send` instead of pulling in a D-Bus crate to keep
+// the dep footprint flat (ksni already gives us all the D-Bus we want at
+// runtime, but its connection is private). If the D-Bus call fails (no
+// FileManager1 owner, or the binary is missing), we fall back to opening
+// the parent directory with xdg-open so the user at least lands close to
+// the target.
+
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+fn linux_reveal(path: &Path) -> std::io::Result<()> {
+    if file_manager_1_show(path).is_ok() {
+        return Ok(());
+    }
+    let parent = file_manager_target_dir(path);
+    run_status("xdg-open", &[parent.as_os_str()])
+}
+
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+fn file_manager_1_show(path: &Path) -> std::io::Result<()> {
+    let uri = format!("file://{}", path.display());
+    let status = std::process::Command::new("dbus-send")
+        .args([
+            "--session",
+            "--dest=org.freedesktop.FileManager1",
+            "--type=method_call",
+            "/org/freedesktop/FileManager1",
+            "org.freedesktop.FileManager1.ShowItems",
+        ])
+        .arg(format!("array:string:{uri}"))
+        .arg("string:")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(format!(
+            "FileManager1.ShowItems exited with {status}"
+        )))
+    }
+}
+
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+fn file_manager_target_dir(path: &Path) -> std::path::PathBuf {
+    if path.is_dir() {
+        path.to_path_buf()
+    } else {
+        path.parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| std::path::PathBuf::from("/"))
+    }
+}

--- a/crates/aura/src/platform.rs
+++ b/crates/aura/src/platform.rs
@@ -19,6 +19,119 @@
 
 use std::path::Path;
 
+// ── Single-instance guard ───────────────────────────────────────────────────
+
+/// Try to acquire the per-user single-instance lock. Returns `true` if this
+/// process is now the sole Aura instance, `false` if another Aura is already
+/// running (in which case `main()` should exit silently — the running tray
+/// icon will service the next click).
+///
+/// Mechanism per platform:
+///
+/// - **Unix (Linux, macOS, BSD)**: an exclusive `flock()` on a file in
+///   `$XDG_RUNTIME_DIR` (Linux/BSD) or `$TMPDIR` (macOS). The lock is held
+///   for the process lifetime — we intentionally leak the file descriptor so
+///   the kernel releases it on exit.
+/// - **Windows**: a named mutex (`Local\AuraSingleInstance`) created via
+///   `CreateMutexW`. `ERROR_ALREADY_EXISTS` from the same call signals
+///   another instance owns it. The handle is leaked for the same reason.
+pub fn acquire_single_instance() -> bool {
+    #[cfg(unix)]
+    {
+        unix_lock::acquire()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        windows_mutex::acquire()
+    }
+    #[cfg(not(any(unix, target_os = "windows")))]
+    {
+        true
+    }
+}
+
+#[cfg(unix)]
+mod unix_lock {
+    use std::os::fd::AsRawFd;
+    use std::path::PathBuf;
+
+    pub fn acquire() -> bool {
+        let path = lock_path();
+        let file = match std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&path)
+        {
+            Ok(f) => f,
+            Err(e) => {
+                // Couldn't even open the lock file — proceed without a
+                // guard rather than refusing to launch. Worst case is two
+                // tray icons appear; both will still work.
+                eprintln!(
+                    "aura: single-instance lock open failed at {}: {e}",
+                    path.display()
+                );
+                return true;
+            }
+        };
+
+        // SAFETY: libc::flock takes a raw fd we just opened. LOCK_EX |
+        // LOCK_NB returns 0 if we acquired the exclusive lock, -1 with
+        // errno EWOULDBLOCK if another process holds it.
+        let ret = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        if ret == 0 {
+            // Keep the descriptor alive for the process lifetime so the
+            // kernel releases the lock automatically on exit (including
+            // SIGKILL / panic). std::mem::forget is fine — the kernel,
+            // not Drop, releases the lock.
+            std::mem::forget(file);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// $XDG_RUNTIME_DIR is per-user and on tmpfs (cleaned at logout) on
+    /// systemd distros — the canonical home for lock files. Fall back to
+    /// `std::env::temp_dir()`, which on macOS resolves to a per-user
+    /// `/var/folders/...` directory (also per-user) and on stripped-down
+    /// Linux to `/tmp`. The fallback is multi-user on /tmp, so we include
+    /// the UID in the filename to avoid stealing each other's lock.
+    fn lock_path() -> PathBuf {
+        if let Some(d) = std::env::var_os("XDG_RUNTIME_DIR") {
+            return PathBuf::from(d).join("aura.lock");
+        }
+        // SAFETY: getuid() is always safe — no inputs, no errno.
+        let uid = unsafe { libc::getuid() };
+        std::env::temp_dir().join(format!("aura-{uid}.lock"))
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod windows_mutex {
+    pub fn acquire() -> bool {
+        use windows::core::w;
+        use windows::Win32::Foundation::{GetLastError, ERROR_ALREADY_EXISTS};
+        use windows::Win32::System::Threading::CreateMutexW;
+        match unsafe { CreateMutexW(None, false, w!("Local\\AuraSingleInstance")) } {
+            Ok(h) => {
+                if unsafe { GetLastError() } == ERROR_ALREADY_EXISTS {
+                    return false;
+                }
+                // HANDLE is Copy; Win32 keeps it open until process exit.
+                let _ = h;
+                true
+            }
+            Err(e) => {
+                eprintln!("aura: single-instance check failed: {e}");
+                true
+            }
+        }
+    }
+}
+
 // ── macOS activation policy ──────────────────────────────────────────────────
 
 /// Set the macOS NSApplication activation policy.

--- a/crates/aura/src/runtime.rs
+++ b/crates/aura/src/runtime.rs
@@ -21,14 +21,29 @@ use aura_core::config::AppConfig;
 /// the user clicks the refresh icon.
 static DISMISS_ON_FOCUS_LOSS: AtomicBool = AtomicBool::new(true);
 
+/// Mirrors `AppConfig.display.show_in_app_switcher`. Used by main.rs
+/// when opening the modal (picks `WindowKind`) and as the source of
+/// truth for the macOS process-wide NSApp activation policy applied at
+/// startup and on every refresh.
+static SHOW_IN_APP_SWITCHER: AtomicBool = AtomicBool::new(false);
+
 /// Returns the latest snapshot of `display.dismiss_on_focus_loss`.
 pub fn dismiss_on_focus_loss() -> bool {
     DISMISS_ON_FOCUS_LOSS.load(Ordering::Relaxed)
 }
 
-/// Push every shared-config field out of `config` into its atomic. Call
-/// this whenever a fresh `AppConfig` lands — at startup, on each tray
-/// click (before opening the modal), and at the end of every refresh.
+/// Returns the latest snapshot of `display.show_in_app_switcher`.
+pub fn show_in_app_switcher() -> bool {
+    SHOW_IN_APP_SWITCHER.load(Ordering::Relaxed)
+}
+
+/// Push every shared-config field out of `config` into its atomic, then
+/// reapply any platform-level state that depends on those fields (today:
+/// the macOS NSApp activation policy). Call this whenever a fresh
+/// `AppConfig` lands — at startup, on each tray click (before opening
+/// the modal), and at the end of every refresh.
 pub fn set_from_config(config: &AppConfig) {
     DISMISS_ON_FOCUS_LOSS.store(config.display.dismiss_on_focus_loss, Ordering::Relaxed);
+    SHOW_IN_APP_SWITCHER.store(config.display.show_in_app_switcher, Ordering::Relaxed);
+    crate::platform::apply_app_switcher_policy(config.display.show_in_app_switcher);
 }

--- a/crates/aura/src/runtime.rs
+++ b/crates/aura/src/runtime.rs
@@ -1,0 +1,34 @@
+//! Cross-cutting runtime state shared by `main.rs` (tray poll loop) and
+//! `app.rs` (the view's refresh task).
+//!
+//! The poll loop in `main()` and the in-modal "Refresh" task each reload
+//! `AppConfig` from disk independently — without a shared bus they'd drift
+//! and the user would see e.g. the modal honour a new
+//! `dismiss_on_focus_loss` value while the tray loop kept using the
+//! startup snapshot. Funnelling both reload paths through
+//! [`set_from_config`] keeps every consumer in sync without threading
+//! `Arc<...>` channels through every callback.
+//!
+//! Add a new atomic / accessor pair here when another `[display]` knob
+//! needs to be visible to both the modal view and the background loop.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use aura_core::config::AppConfig;
+
+/// Mirrors `AppConfig.display.dismiss_on_focus_loss`. The poll loop
+/// reads it every 150 ms; the modal's refresh task updates it whenever
+/// the user clicks the refresh icon.
+static DISMISS_ON_FOCUS_LOSS: AtomicBool = AtomicBool::new(true);
+
+/// Returns the latest snapshot of `display.dismiss_on_focus_loss`.
+pub fn dismiss_on_focus_loss() -> bool {
+    DISMISS_ON_FOCUS_LOSS.load(Ordering::Relaxed)
+}
+
+/// Push every shared-config field out of `config` into its atomic. Call
+/// this whenever a fresh `AppConfig` lands — at startup, on each tray
+/// click (before opening the modal), and at the end of every refresh.
+pub fn set_from_config(config: &AppConfig) {
+    DISMISS_ON_FOCUS_LOSS.store(config.display.dismiss_on_focus_loss, Ordering::Relaxed);
+}

--- a/crates/aura/src/work_area.rs
+++ b/crates/aura/src/work_area.rs
@@ -7,20 +7,27 @@
 //! 2. `main.rs` `toggle_window`: anchors the modal at the bottom-right
 //!    corner of the work area so it appears where the tray icon lives.
 //!
-//! On KDE Plasma we parse the user's panel config files directly; on
-//! every other platform / parse failure we return `None` and let the
-//! caller fall back to a conservative blind margin.
+//! Per-platform sources, in order of preference:
 //!
-//! ## Why config-file parsing instead of D-Bus
+//! - **macOS**: `NSScreen.visibleFrame` returns the screen rect minus
+//!   the menu bar and any docked Dock — the canonical answer.
+//! - **Windows**: `SystemParametersInfoW(SPI_GETWORKAREA)` returns the
+//!   work-area rect in physical pixels; we cache the bottom-fraction so
+//!   the DPI scale cancels out.
+//! - **Linux KDE Plasma**: parse `~/.config/plasmashellrc` +
+//!   `plasma-org.kde.plasma.desktop-appletsrc` for bottom-panel
+//!   thickness. KDE's `StrutManager.availableScreenRect` D-Bus API
+//!   would be cleaner but returns the full display rect on the versions
+//!   we tested.
+//! - **Linux X11 / XWayland**: read the root window's `_NET_WORKAREA`
+//!   property via `xprop`. Covers GNOME, XFCE, Cinnamon, MATE, i3, and
+//!   any other reasonably standards-compliant X11 DE.
+//! - **Pure Wayland without XWayland**: no portable source today;
+//!   `xprop` will fail and the caller falls back to a blind margin.
 //!
-//! KDE Plasma 6's `org.kde.PlasmaShell.StrutManager.availableScreenRect`
-//! returns the **full** display rect on the versions we tested — the
-//! strut manager is a setter registry that panels register themselves
-//! with, but the read side doesn't subtract those struts. The panel
-//! thickness is, however, reliably persisted to `~/.config/plasmashellrc`,
-//! so we read it from there and correlate with
-//! `~/.config/plasma-org.kde.plasma.desktop-appletsrc` to find which
-//! panels live at the bottom.
+//! All lookups are cached process-wide. Users who resize their panel
+//! without restarting Aura get stale numbers — a fine tradeoff vs.
+//! re-querying on every resize frame.
 
 use gpui::{Bounds, Pixels};
 
@@ -29,26 +36,67 @@ use gpui::{Bounds, Pixels};
 /// display's top-left) of the available work area for `display`.
 ///
 /// `None` means "couldn't determine a panel reservation; fall back to
-/// whatever blind margin the caller has in mind". This happens on
-/// non-Linux platforms, on Linux without KDE Plasma config files
-/// present, or on any I/O / parse error.
-///
-/// The lookup is cached process-wide after the first call. Users who
-/// resize their panel without restarting Aura get stale numbers — a
-/// fine tradeoff vs. re-reading the files on every resize frame.
+/// whatever blind margin the caller has in mind." See the module-level
+/// docstring for the per-platform sources tried.
 pub fn available_bottom(display: Bounds<Pixels>) -> Option<f32> {
     #[cfg(target_os = "linux")]
     {
         linux::available_bottom(display)
     }
+    #[cfg(target_os = "macos")]
+    {
+        macos::available_bottom(display)
+    }
     #[cfg(target_os = "windows")]
     {
         windows_impl::available_bottom(display)
     }
-    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
     {
         let _ = display;
         None
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use std::sync::OnceLock;
+
+    use gpui::{Bounds, Pixels};
+
+    /// Cached `Some(bottom_reservation_px)` — the height taken by a
+    /// bottom-anchored Dock. `None` means we tried and couldn't ask
+    /// NSScreen (no main screen, unusual platform, etc.).
+    static CACHED_BOTTOM_RESERVATION: OnceLock<Option<f32>> = OnceLock::new();
+
+    pub fn available_bottom(display: Bounds<Pixels>) -> Option<f32> {
+        let dock = (*CACHED_BOTTOM_RESERVATION.get_or_init(query_bottom_reservation))?;
+        let display_bottom = f32::from(display.origin.y + display.size.height);
+        Some(display_bottom - dock)
+    }
+
+    /// Query NSScreen.visibleFrame on the main screen. macOS uses a
+    /// bottom-left origin: `visibleFrame.origin.y` is the height of the
+    /// bottom-docked Dock (0 when the Dock is auto-hidden or anchored
+    /// to a side).
+    fn query_bottom_reservation() -> Option<f32> {
+        use cocoa::base::nil;
+        use cocoa::foundation::NSRect;
+        use objc::{class, msg_send, sel, sel_impl};
+
+        unsafe {
+            let screen: cocoa::base::id = msg_send![class!(NSScreen), mainScreen];
+            if screen == nil {
+                return None;
+            }
+            let visible: NSRect = msg_send![screen, visibleFrame];
+            let bottom_dock = visible.origin.y as f32;
+            if bottom_dock.is_nan() || bottom_dock < 0.0 {
+                None
+            } else {
+                Some(bottom_dock)
+            }
+        }
     }
 }
 
@@ -106,12 +154,14 @@ mod linux {
     use gpui::{Bounds, Pixels};
 
     /// Cached `Some(thickness_px)` for the bottom panel (or the
-    /// thickest of several stacked panels). `None` means we tried and
-    /// couldn't determine a reservation.
+    /// thickest of several stacked panels). `None` means we tried KDE
+    /// config + `xprop` and neither produced an answer.
     static CACHED_BOTTOM_THICKNESS: OnceLock<Option<f32>> = OnceLock::new();
 
     pub fn available_bottom(display: Bounds<Pixels>) -> Option<f32> {
-        let thickness = (*CACHED_BOTTOM_THICKNESS.get_or_init(query_bottom_panel_thickness))?;
+        let thickness = (*CACHED_BOTTOM_THICKNESS.get_or_init(|| {
+            query_bottom_panel_thickness().or_else(|| query_xprop_bottom_strut(display))
+        }))?;
         let display_bottom = f32::from(display.origin.y + display.size.height);
         Some(display_bottom - thickness)
     }
@@ -138,6 +188,61 @@ mod linux {
             .filter_map(|id| thicknesses.get(id))
             .copied()
             .reduce(f32::max)
+    }
+
+    /// Read the root window's `_NET_WORKAREA` property via `xprop` and
+    /// derive the bottom reservation. Works on any X11 session — and on
+    /// XWayland-backed Wayland sessions, which is most of them. Returns
+    /// `None` on pure Wayland (no xprop available, or xprop has no X
+    /// display to talk to).
+    ///
+    /// `_NET_WORKAREA(CARDINAL)` is a list of 4-tuples (x, y, w, h), one
+    /// per virtual desktop. We use the first tuple — Aura's window
+    /// rules pin the modal to the current desktop anyway.
+    fn query_xprop_bottom_strut(display: Bounds<Pixels>) -> Option<f32> {
+        let output = std::process::Command::new("xprop")
+            .args(["-root", "_NET_WORKAREA"])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let stdout = std::str::from_utf8(&output.stdout).ok()?;
+        parse_xprop_bottom_strut(stdout, f32::from(display.size.height))
+    }
+
+    /// Pure parser for the xprop response. Returns the height of the
+    /// bottom reservation (panel/taskbar height), or `None` if the
+    /// response is unparsable or describes a multi-monitor virtual root
+    /// we can't safely interpret.
+    fn parse_xprop_bottom_strut(stdout: &str, display_h: f32) -> Option<f32> {
+        // Expected line: `_NET_WORKAREA(CARDINAL) = 0, 24, 1920, 1056`.
+        let after_eq = stdout.split_once('=')?.1.trim();
+        let parts: Vec<f32> = after_eq
+            .split(',')
+            .filter_map(|p| p.trim().parse::<f32>().ok())
+            .collect();
+        if parts.len() < 4 {
+            return None;
+        }
+        let work_y = parts[1];
+        let work_h = parts[3];
+        if display_h <= 0.0 {
+            return None;
+        }
+        // Most X11/XWayland sessions run at scale 1.0 and the rect
+        // matches our logical display. If the work-area rect's bottom
+        // edge exceeds display_h, we're looking at a multi-monitor
+        // virtual root — return None rather than guess which monitor.
+        if work_y + work_h > display_h + 1.0 {
+            return None;
+        }
+        let reservation = display_h - (work_y + work_h);
+        if reservation < 0.0 {
+            None
+        } else {
+            Some(reservation)
+        }
     }
 
     /// IDs of `[Containments][N]` sections whose `location=4` (Plasma's
@@ -259,6 +364,34 @@ thickness=60
             assert_eq!(parse_containment_root_id("Containments][2]"), Some(2));
             assert_eq!(parse_containment_root_id("Containments][2][General]"), None);
             assert_eq!(parse_containment_root_id("PlasmaViews][Panel 2]"), None);
+        }
+
+        #[test]
+        fn parses_xprop_workarea_bottom_panel() {
+            // GNOME / XFCE with a top bar of 27px on a 1080px screen
+            // → workarea y=27 h=1053 → bottom reservation = 0.
+            let stdout = "_NET_WORKAREA(CARDINAL) = 0, 27, 1920, 1053\n";
+            assert_eq!(parse_xprop_bottom_strut(stdout, 1080.0), Some(0.0));
+
+            // Bottom-panel case: y=0, h=1024 on 1080px → 56px reserved
+            // at the bottom.
+            let stdout = "_NET_WORKAREA(CARDINAL) = 0, 0, 1920, 1024\n";
+            assert_eq!(parse_xprop_bottom_strut(stdout, 1080.0), Some(56.0));
+        }
+
+        #[test]
+        fn parses_xprop_workarea_rejects_virtual_root() {
+            // Two monitors stacked vertically → workarea y=0, h=2160 on
+            // a 1080 logical display. We can't safely interpret this.
+            let stdout = "_NET_WORKAREA(CARDINAL) = 0, 0, 1920, 2160\n";
+            assert_eq!(parse_xprop_bottom_strut(stdout, 1080.0), None);
+        }
+
+        #[test]
+        fn parses_xprop_workarea_rejects_garbage() {
+            assert_eq!(parse_xprop_bottom_strut("not a property", 1080.0), None);
+            assert_eq!(parse_xprop_bottom_strut("= a, b, c, d", 1080.0), None);
+            assert_eq!(parse_xprop_bottom_strut("= 0, 0, 1920", 1080.0), None);
         }
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,10 +92,13 @@ anchor = "auto"
 # which is handy when copy-pasting from the modal into another window.
 dismiss_on_focus_loss = true
 
-# macOS only: appear in Cmd+Tab app switcher and the Dock.
-# Default false — Aura runs as an Accessory app (menu-bar only) so it
-# doesn't clutter the switcher. The settings panel exposes this as a
-# toggle that applies immediately without a restart.
+# Appear in the OS's "where are my windows" surfaces:
+# - macOS:   Cmd+Tab app switcher + Dock (NSApp activation policy)
+# - Windows: Alt+Tab + taskbar (WS_EX_APPWINDOW vs WS_EX_TOOLWINDOW)
+# - Linux:   panel / window switcher (WindowKind::Normal vs PopUp)
+# Default false — Aura runs as a tray-only indicator. Reapplies on the
+# next refresh (modal Refresh button) or modal open, so a config edit
+# takes effect without restarting the service.
 show_in_app_switcher = false
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,18 @@ plugin_order = ["Hello", "RTK Gains"]
 # Options: "auto" | "top" | "bottom" | "left" | "right"
 # "auto" lets Aura pick based on available screen space
 anchor = "auto"
+
+# Auto-close the modal when it loses focus (click outside, switch app).
+# Default true — matches typical menu-bar / tray-popup behaviour. Set
+# to false to make the modal sticky (only the tray icon closes it),
+# which is handy when copy-pasting from the modal into another window.
+dismiss_on_focus_loss = true
+
+# macOS only: appear in Cmd+Tab app switcher and the Dock.
+# Default false — Aura runs as an Accessory app (menu-bar only) so it
+# doesn't clutter the switcher. The settings panel exposes this as a
+# toggle that applies immediately without a restart.
+show_in_app_switcher = false
 ```
 
 ## Agent kinds

--- a/docs/platform-tray-icon.md
+++ b/docs/platform-tray-icon.md
@@ -1,0 +1,197 @@
+---
+title: Platform integration — clickable tray icon
+status: draft
+version: 0.1.0
+last_updated: 2026-05-24
+last_verified: 2026-05-24
+source_refs:
+  - crates/aura/src/tray.rs
+  - crates/aura/src/main.rs
+  - crates/aura/src/platform.rs
+  - crates/aura/src/work_area.rs
+owner: "@rfluid"
+tags: [architecture, platform, docs]
+---
+
+# Platform integration: making Aura a clickable tray icon everywhere
+
+Aura is a tray-indicator app: the icon next to the clock is the *entire* UI.
+Primary-click toggles a small modal anchored near the icon; right-click
+opens a tiny context menu (Show / Quit). Achieving this UX on Linux, macOS,
+and Windows with a single GPUI codebase requires a different combination of
+host APIs on each platform. This document is the map.
+
+## Tray icon backend
+
+| Platform        | Crate / API                              | Why                                                                                                   | Source              |
+| --------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------- |
+| Linux / BSD     | [`ksni`](https://crates.io/crates/ksni)  | StatusNotifierItem over D-Bus. KDE/GNOME/Cinnamon emit `Activate()` on primary-click — the one-click UX. | `tray.rs::linux`    |
+| macOS / Windows | [`tray-icon`](https://crates.io/crates/tray-icon) | AppKit `NSStatusItem` / Win32 `Shell_NotifyIconW`. Native handlers, no GTK dependency.              | `tray.rs::non_linux` |
+
+The two backends share a `TrayEvent` enum (`Show { hint: Option<(i32, i32)> }`
+/ `Quit`) and a `try_recv_event()` poller; the main loop drains events
+every 150 ms regardless of platform.
+
+The Linux `ksni` backend uses `libayatana-appindicator`'s wire protocol but
+talks D-Bus directly — `tray-icon`'s `gtk` feature refuses to surface
+primary-click on AppIndicator hosts (it expects a menu and treats click as
+"open menu"), so we picked an SNI-native implementation instead.
+
+## Modal positioning
+
+`main.rs::compute_modal_bounds()` decides where the modal opens; the choice
+is OS-specific because that's where the tray icon lives:
+
+- **macOS**: tray icon is at the **top** in the menu bar. Modal anchors
+  ~25 pt below the bar, horizontally centred on the click X coordinate
+  (`hint.0` from `TrayEvent::Show`).
+- **Linux / Windows**: tray icon is in the bottom-right (or wherever the
+  user put their panel/taskbar). Modal anchors to the bottom-right of the
+  *work area* (display minus reserved panel space — see
+  [Work-area detection](#work-area-detection)).
+  Wayland compositors may ignore the requested origin and centre the
+  window. KDE users can install a window rule matching `app_id="aura"` to
+  force the position (`Window matches: WM_CLASS = aura` → Position =
+  Apply Initially). See the README "Modal placement on Wayland" section.
+
+## Click-outside auto-dismiss
+
+The main poll loop polls `cx.active_window()` every 150 ms; when it returns
+`None` (no GPUI window is the OS-foreground window) the modal is closed.
+
+A grace period of four polls (~600 ms) starts each time the modal opens,
+because:
+
+- **Windows**: `cx.activate(true)` is a no-op; Win32 has to deliver focus
+  asynchronously after the window is mapped.
+- **Wayland (KDE/GNOME/etc.)**: focus is delivered after the surface has
+  been mapped and committed; on some compositors that takes a frame or two.
+
+Without the grace period the modal would close itself before the user
+saw it.
+
+The hidden keepalive window (next section) is `minimize_window()`'d at
+startup and never becomes "active" in the OS sense, so it doesn't poison
+the focus check.
+
+## Keepalive window
+
+`main.rs::open_keepalive_window` opens a 1×1, off-screen, minimized GPUI
+window at startup. Reason:
+
+> GPUI 0.2's Wayland backend exits the event loop when the last window
+> closes (`wayland/client.rs` checks `state.windows.is_empty()`). The tray
+> icon is *not* a GPUI window, so the moment the user closes the modal we'd
+> lose the process. The keepalive guarantees `state.windows.len() ≥ 1` for
+> the lifetime of the tray.
+
+Hardening (per call-site):
+
+- Origin at `(-9999, -9999)` so even if the compositor doesn't clamp it
+  back on-screen, the user can't accidentally focus or click it.
+- `minimize_window()` immediately — KDE puts it straight into the taskbar
+  overflow instead of painting it on the desktop.
+- `app_id = "aura-keepalive"` so KDE's task manager doesn't group it under
+  the main "Aura" entry.
+- `on_window_should_close` returns `false` — clicking the compositor's
+  "close window" action on the keepalive becomes a no-op, so the tray
+  can't be killed by a stray click. The internal `window.remove_window()`
+  used by the toggle path bypasses this guard (it's an internal close,
+  not a platform request).
+
+The keepalive is harmless on macOS/Windows where GPUI doesn't quit on
+last-window-close, but the unconditional opening keeps the code path the
+same on all platforms.
+
+## Single-instance guard
+
+`platform::acquire_single_instance()` (called at the top of `main()`)
+prevents two Aura tray icons from racing during autostart. Returns `false`
+if another instance already holds the lock; `main()` returns `Ok(())`
+silently in that case so the user just sees the existing tray icon.
+
+| Platform | Mechanism                                                 | Lock path                                              |
+| -------- | --------------------------------------------------------- | ------------------------------------------------------ |
+| Unix     | `flock(fd, LOCK_EX \| LOCK_NB)` on a per-user lockfile.   | `$XDG_RUNTIME_DIR/aura.lock` (tmpfs on systemd); else `$TMPDIR/aura-<uid>.lock`. |
+| Windows  | `CreateMutexW(L"Local\\AuraSingleInstance")` + `GetLastError() == ERROR_ALREADY_EXISTS`. | (no file path; kernel object) |
+
+Both implementations leak their handle / fd intentionally — the OS
+releases the lock on process exit (including SIGKILL / panic), so a Drop
+dance isn't required and can't be sabotaged by a panic during shutdown.
+
+## Work-area detection
+
+The modal's auto-resize callback (`app.rs::on_children_prepainted`) caps
+its height so it never grows into a bottom taskbar / Dock. The cap source
+ladder lives in `work_area::available_bottom`:
+
+| Source                                                  | Coverage                                                              |
+| ------------------------------------------------------- | --------------------------------------------------------------------- |
+| `NSScreen.visibleFrame.origin.y` (macOS)                | Subtracts the bottom Dock height (0 when auto-hidden or side-docked). |
+| `SystemParametersInfoW(SPI_GETWORKAREA)` (Windows)      | Returns physical work-area rect; we cache the bottom-fraction so DPI scale cancels out. |
+| `~/.config/plasmashellrc` + `plasma-org.kde.plasma.desktop-appletsrc` (Linux KDE Plasma) | Reads the thickest bottom-anchored panel's `thickness=` value. KDE's `StrutManager.availableScreenRect` D-Bus API returns the full display rect on the versions we tested — config parsing is the workaround. |
+| `xprop -root _NET_WORKAREA` (Linux X11 / XWayland)      | Reads the EWMH work-area property. Covers GNOME, XFCE, Cinnamon, MATE, i3, and any other reasonably standards-compliant X11 DE. Multi-monitor virtual roots are rejected to avoid guessing which monitor we're on. |
+| Blind 120 px reserve (everything else, including pure Wayland without XWayland) | Conservative fallback; matches a "Huge" KDE Plasma panel and a default macOS Dock so a misdetection still lands the modal above the taskbar in the common case. |
+
+The lookup is cached process-wide after the first call; resizing your
+panel without restarting Aura yields stale numbers, which is preferable to
+hitting the file system / D-Bus on every resize frame.
+
+## macOS Accessory mode
+
+GPUI forces `NSApplicationActivationPolicyRegular` in `did_finish_launching`,
+which would make Aura appear in Cmd+Tab and the Dock. For a tray-indicator
+that's noise. `platform::apply_app_switcher_policy` flips the policy to
+`Accessory` (menu-bar-only, no Dock icon, no Cmd+Tab) right after GPUI
+finishes launching.
+
+Users who want Aura in the Cmd+Tab list (e.g. to alt-tab to the modal) can
+flip `display.show_in_app_switcher = true` in `config.toml` or use the
+"Show in App Switcher" toggle in the settings panel — the change applies
+immediately, no restart.
+
+## File-handler dispatch
+
+`platform::open_path()` opens a file with the OS default handler, falling
+back to the system file manager (with the file pre-selected when supported)
+if no handler is registered.
+
+| Step | Linux                                                                  | macOS                       | Windows                                                                |
+| ---- | ---------------------------------------------------------------------- | --------------------------- | ---------------------------------------------------------------------- |
+| Open | `xdg-open <path>`                                                      | `open <path>`               | `ShellExecuteW(NULL, "open", path, ...)`                               |
+| Fall back to reveal | `dbus-send … org.freedesktop.FileManager1.ShowItems` → `xdg-open <parent_dir>` | `open -R <path>` (Finder selects the file) | `explorer.exe /select,<path>`                                          |
+
+`platform::open_url()` is the same dispatcher minus the file-manager
+fallback (a missing browser is a different kind of broken). All work
+happens on a detached thread so the GPUI click handler returns immediately.
+
+## Why this pattern (cross-reference: Zed)
+
+Zed ships a similar `Platform` trait with `open_with_system` and
+`reveal_path` methods, dispatched to per-OS impls in `crates/gpui_linux/`,
+`crates/gpui_macos/`, `crates/gpui_windows/`. The implementations are very
+similar to what we have here — `xdg-open`, `open -R`, `ShellExecuteW`,
+`SHOpenFolderAndSelectItems`. The main divergence is that Zed pulls in
+`ashpd` for sandbox-aware portal-based reveals on Linux; Aura shells out
+to `dbus-send` to avoid the dep (we never run sandboxed). That's a tradeoff
+worth revisiting if Flatpak distribution lands on the roadmap.
+
+## Adding a new platform
+
+The pattern that emerged from the existing implementations:
+
+1. **Tray backend** — if `ksni` or `tray-icon` already supports the platform,
+   add it to the relevant cfg block in `tray.rs`. Otherwise the
+   `TrayEvent`/`try_recv_event` contract is the seam to write a new
+   backend against.
+2. **Modal positioning** — add a `#[cfg(target_os = "newos")]` branch in
+   `main.rs::compute_modal_bounds`. The Linux/Windows branch is the
+   right starting point for any platform with a bottom-anchored tray.
+3. **Single-instance** — add a cfg branch in
+   `platform::acquire_single_instance`. The unix `flock` impl is the
+   simplest and tends to work as-is on any new Unix.
+4. **Work-area detection** — add a module under `work_area.rs` that
+   returns the bottom reservation. If you can't find a native API, the
+   blind 120 px reserve is fine until users complain.
+5. **Document it here** — extend the tables above so the next port has
+   the contract spelled out.

--- a/docs/platform-tray-icon.md
+++ b/docs/platform-tray-icon.md
@@ -137,18 +137,27 @@ The lookup is cached process-wide after the first call; resizing your
 panel without restarting Aura yields stale numbers, which is preferable to
 hitting the file system / D-Bus on every resize frame.
 
-## macOS Accessory mode
+## Show-in-app-switcher (cross-platform)
 
-GPUI forces `NSApplicationActivationPolicyRegular` in `did_finish_launching`,
-which would make Aura appear in Cmd+Tab and the Dock. For a tray-indicator
-that's noise. `platform::apply_app_switcher_policy` flips the policy to
-`Accessory` (menu-bar-only, no Dock icon, no Cmd+Tab) right after GPUI
-finishes launching.
+`display.show_in_app_switcher` controls whether Aura's modal appears in
+each OS's "where are my windows" surfaces:
 
-Users who want Aura in the Cmd+Tab list (e.g. to alt-tab to the modal) can
-flip `display.show_in_app_switcher = true` in `config.toml` or use the
-"Show in App Switcher" toggle in the settings panel — the change applies
-immediately, no restart.
+| Platform | `false` (default)                                        | `true`                                                          |
+| -------- | -------------------------------------------------------- | --------------------------------------------------------------- |
+| macOS    | `NSApplicationActivationPolicyAccessory` (menu-bar only) | `NSApplicationActivationPolicyRegular` (Cmd+Tab + Dock)         |
+| Windows  | `WindowKind::PopUp` → `WS_EX_TOOLWINDOW` (no taskbar entry) | `WindowKind::Normal` → `WS_EX_APPWINDOW` (Alt+Tab + taskbar)    |
+| Linux    | `WindowKind::PopUp` (skipped by most DEs' window list)   | `WindowKind::Normal` (visible to the panel / window switcher)   |
+
+The macOS policy is process-wide and is applied at startup *and* on every
+modal refresh, so editing the field in `config.toml` and clicking the
+refresh icon (or just reopening the modal) picks up the new value
+without a service restart. On Windows / Linux the field is read at modal
+open time — clicking the tray icon to reopen swaps the `WindowKind`.
+
+GPUI forces `NSApplicationActivationPolicyRegular` in
+`did_finish_launching`, which would override our setting on first launch.
+`platform::apply_app_switcher_policy` is therefore reapplied inside the
+GPUI `run` closure (after launching completes) to win the race.
 
 ## File-handler dispatch
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,3 +47,10 @@ _Goal: working widget for Claude Code usage with RTK Gains plugin_
 - Cost alerts / budget warnings
 - Per-project usage breakdown (if agents expose project-scoped data)
 - Historical usage charts (daily/weekly trend in the modal)
+- **In-modal config editor page** — a settings page inside the modal that
+  exposes every `[display]` / agent / plugin field as a real form, so
+  users don't have to open `~/.config/aura/config.toml` to change
+  anything. Replaces the ad-hoc "Open config file" / per-field toggle
+  approach that grew during 0.1. Should reuse the `runtime` bus so
+  changes apply without a service restart for every field already
+  funnelled through it.


### PR DESCRIPTION
- **feat(ui): consolidate theme entry into cross-platform settings menu**
- **feat(platform): cross-OS open_path / open_url with file-manager fallback**
- **feat(focus): enable click-outside dismiss on Linux**
- **feat(work-area): macOS NSScreen + Linux X11 _NET_WORKAREA fallbacks**
- **feat(single-instance): cross-OS lock via flock (unix) + named mutex (windows)**
- **docs: per-platform tray-icon machinery**
- **feat(config): display.dismiss_on_focus_loss toggle (default true)**
- **feat(config): hot-reload AppConfig on tray click and refresh button**
- **feat(ui): cross-platform show_in_app_switcher, drop the inline toggle**
