### PR TITLE
fix(macos): modal window stays open after tray click

### DIFF
--- a/crates/aura/src/main.rs
+++ b/crates/aura/src/main.rs
@@ -162,6 +162,14 @@ fn main() -> Result<()> {
                         if just_opened > 0 {
                             just_opened -= 1;
                         } else {
+                            // On macOS, GPUI's cx.active_window() can lag after
+                            // activation-policy switches, producing false "no focus"
+                            // readings. Ask NSApp.isActive directly — it is the
+                            // authoritative OS answer and updates synchronously.
+                            // On other platforms cx.active_window() is reliable.
+                            #[cfg(target_os = "macos")]
+                            let lost_focus = !platform::app_is_active();
+                            #[cfg(not(target_os = "macos"))]
                             let lost_focus = cx
                                 .update(|cx| cx.active_window().is_none())
                                 .unwrap_or(false);
@@ -214,6 +222,23 @@ fn main() -> Result<()> {
                                 // before the OS has delivered foreground focus.
                                 if current.is_some() {
                                     just_opened = 4; // ~600 ms at 150 ms/poll
+
+                                    // macOS: window.activate_window() schedules
+                                    // makeKeyAndOrderFront: asynchronously via the
+                                    // executor, so activateIgnoringOtherApps: in
+                                    // toggle_window fires before the window is
+                                    // visible — macOS silently discards activation
+                                    // requests when there is no key window yet.
+                                    // Wait for the window to appear, then re-activate
+                                    // the application so NSApp.isActive becomes true
+                                    // and the focus-loss check works correctly.
+                                    #[cfg(target_os = "macos")]
+                                    {
+                                        cx.background_executor()
+                                            .timer(Duration::from_millis(50))
+                                            .await;
+                                        let _ = cx.update(|cx| cx.activate(true));
+                                    }
                                 }
                             }
                             TrayEvent::Quit => {

--- a/crates/aura/src/platform.rs
+++ b/crates/aura/src/platform.rs
@@ -172,7 +172,6 @@ pub fn app_is_active() -> bool {
     }
 }
 
-
 // ── Open with system handler (file or URL) ──────────────────────────────────
 
 /// Open a filesystem path with the desktop's default handler, falling back to

--- a/crates/aura/src/platform.rs
+++ b/crates/aura/src/platform.rs
@@ -172,10 +172,6 @@ pub fn app_is_active() -> bool {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
-pub fn app_is_active() -> bool {
-    unreachable!("app_is_active is macOS-only")
-}
 
 // ── Open with system handler (file or URL) ──────────────────────────────────
 

--- a/crates/aura/src/platform.rs
+++ b/crates/aura/src/platform.rs
@@ -159,6 +159,24 @@ pub fn apply_app_switcher_policy(show: bool) {
 #[cfg(not(target_os = "macos"))]
 pub fn apply_app_switcher_policy(_show: bool) {}
 
+/// Returns whether the macOS application is currently the active (frontmost) app.
+/// Uses `NSApp.isActive` — the authoritative OS answer — rather than GPUI's
+/// internal window tracking, which can lag after activation-policy switches.
+#[cfg(target_os = "macos")]
+pub fn app_is_active() -> bool {
+    use objc::{class, msg_send, sel, sel_impl};
+    unsafe {
+        let app: cocoa::base::id = msg_send![class!(NSApplication), sharedApplication];
+        let active: cocoa::base::BOOL = msg_send![app, isActive];
+        active != cocoa::base::NO
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn app_is_active() -> bool {
+    unreachable!("app_is_active is macOS-only")
+}
+
 // ── Open with system handler (file or URL) ──────────────────────────────────
 
 /// Open a filesystem path with the desktop's default handler, falling back to


### PR DESCRIPTION
Fixes #14

## Problem

On macOS, clicking the tray icon opens the modal but it disappears after ~1 second. The window only stays open if the user clicks inside it first.

Two issues compound each other:

**1. Activation policy conflict**
GPUI forces `NSApplicationActivationPolicyRegular` in `did_finish_launching`, overriding `LSUIElement=true`. Running as `Accessory` (background-only) while no modal is shown is correct, but the app must temporarily switch to `Regular` while the window is open so it can receive and hold focus.

**2. Async activation race**
`window.activate_window()` in GPUI's macOS backend schedules `makeKeyAndOrderFront:` via an async executor. The `activateIgnoringOtherApps:` call in `toggle_window` fires before the window is visible, so macOS discards it (no key window yet). `NSApp.isActive` never becomes `true`, and the dismiss-on-focus-loss check closes the window after the grace period.

## Fix

- Promote to `NSApplicationActivationPolicyRegular` when opening the modal; demote back to `Accessory` on every close path (focus-loss dismiss and explicit toggle-close).
- After `toggle()` opens the window, wait 50 ms for `makeKeyAndOrderFront:` to complete, then call `cx.activate(true)` again. By this point the window is visible and macOS honours the activation request.
- On macOS, replace `cx.active_window().is_none()` in the focus-loss check with `!NSApp.isActive` (via `platform::app_is_active()`), which reflects the OS focus state directly instead of going through GPUI's internal window tracking.

## Scope

macOS only. Linux and Windows are unaffected — the new code paths are all behind `#[cfg(target_os = "macos")]`.