### PR TITLE
fix(macos): use global NSEvent monitor to detect clicks outside modal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,7 @@ version = "0.1.15"
 dependencies = [
  "anyhow",
  "aura-core",
+ "block",
  "chrono",
  "clap",
  "clap_complete",

--- a/crates/aura/Cargo.toml
+++ b/crates/aura/Cargo.toml
@@ -63,3 +63,8 @@ windows = { version = "0.61", features = [
     "Win32_UI_Shell",
 ] }
 
+[lints.rust]
+# objc 0.2 macros (msg_send!, class!, sel_impl!) emit #[cfg(cargo-clippy)]
+# internally. Register it as expected so the unexpected_cfgs lint stays quiet.
+unexpected_cfgs = "allow"
+

--- a/crates/aura/Cargo.toml
+++ b/crates/aura/Cargo.toml
@@ -50,6 +50,7 @@ tray-icon = { version = "0.24", default-features = false }
 libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+block = "0.1"
 cocoa = "=0.26.0"
 objc  = "0.2"
 

--- a/crates/aura/src/main.rs
+++ b/crates/aura/src/main.rs
@@ -11,6 +11,10 @@ mod runtime;
 mod tray;
 mod work_area;
 
+#[cfg(target_os = "macos")]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(target_os = "macos")]
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
@@ -133,13 +137,20 @@ fn main() -> Result<()> {
                 // "Show Aura" click: open if closed, close if open.
                 let mut current: Option<WindowHandle<AuraView>> = None;
 
-                // Grace-period counter: skip focus-loss checks for this many
-                // poll intervals after opening the modal. On Windows,
-                // cx.activate() is a no-op and the new window needs a moment
-                // for Win32 to grant foreground focus; checking too soon makes
-                // the modal close itself immediately. The same race shows up
-                // on Wayland compositors that defer focus events until the
-                // surface has been mapped and committed.
+                // macOS: global NSEvent monitor that fires when the user
+                // clicks in any OTHER application. When it fires we set this
+                // flag; the poll loop checks it and closes the window.
+                // This avoids needing to steal focus — menu bar apps on
+                // modern macOS can't reliably do that programmatically.
+                #[cfg(target_os = "macos")]
+                let outside_clicked = Arc::new(AtomicBool::new(false));
+                #[cfg(target_os = "macos")]
+                let mut click_monitor: Option<platform::ClickOutsideMonitor> = None;
+
+                // Grace-period counter for non-macOS platforms: skip
+                // focus-loss checks for this many poll intervals after
+                // opening the modal so Win32 / Wayland can deliver focus.
+                #[cfg(not(target_os = "macos"))]
                 let mut just_opened: u8 = 0;
 
                 loop {
@@ -148,44 +159,43 @@ fn main() -> Result<()> {
                     // them between short sleeps.
                     cx.background_executor().timer(MENU_POLL_INTERVAL).await;
 
-                    // Auto-close when the user clicks outside the modal:
-                    // cx.active_window() returns None once another app takes
-                    // focus; we treat that as "dismiss". The keepalive window
-                    // is hidden and never active, so it doesn't interfere.
-                    // Skip this check during the grace period after opening,
-                    // and skip it entirely when the user has opted out via
-                    // display.dismiss_on_focus_loss=false. The flag is read
-                    // from `runtime::dismiss_on_focus_loss()` on every poll
-                    // so a refresh-button click or a tray-click reload picks
-                    // up the new value without a service restart.
+                    // Auto-close when the user clicks outside the modal.
+                    // macOS: a global NSEvent monitor flags outside clicks
+                    //   without needing focus ownership (reliable on Sonoma+).
+                    // Other platforms: cx.active_window() goes None when
+                    //   another app takes focus.
+                    // Skipped entirely when dismiss_on_focus_loss=false.
                     if runtime::dismiss_on_focus_loss() && current.is_some() {
-                        if just_opened > 0 {
+                        #[cfg(target_os = "macos")]
+                        let lost_focus =
+                            outside_clicked.load(Ordering::Relaxed);
+
+                        #[cfg(not(target_os = "macos"))]
+                        let lost_focus = if just_opened > 0 {
                             just_opened -= 1;
+                            false
                         } else {
-                            // On macOS, GPUI's cx.active_window() can lag after
-                            // activation-policy switches, producing false "no focus"
-                            // readings. Ask NSApp.isActive directly — it is the
-                            // authoritative OS answer and updates synchronously.
-                            // On other platforms cx.active_window() is reliable.
+                            cx.update(|cx| cx.active_window().is_none())
+                                .unwrap_or(false)
+                        };
+
+                        if lost_focus {
                             #[cfg(target_os = "macos")]
-                            let lost_focus = !platform::app_is_active();
-                            #[cfg(not(target_os = "macos"))]
-                            let lost_focus = cx
-                                .update(|cx| cx.active_window().is_none())
-                                .unwrap_or(false);
-                            if lost_focus {
-                                if let Some(handle) = current.take() {
-                                    let _ = cx.update(|cx| {
-                                        let _ = handle.update(cx, |_view, window, _cx| {
-                                            window.remove_window()
-                                        });
-                                    });
-                                    // Demote back to Accessory now that no modal is open.
-                                    #[cfg(target_os = "macos")]
-                                    if !runtime::show_in_app_switcher() {
-                                        platform::apply_app_switcher_policy(false);
-                                    }
+                            {
+                                outside_clicked.store(false, Ordering::Relaxed);
+                                if let Some(m) = click_monitor.take() {
+                                    platform::remove_click_outside_monitor(m);
                                 }
+                                if !runtime::show_in_app_switcher() {
+                                    platform::apply_app_switcher_policy(false);
+                                }
+                            }
+                            if let Some(handle) = current.take() {
+                                let _ = cx.update(|cx| {
+                                    let _ = handle.update(cx, |_view, window, _cx| {
+                                        window.remove_window()
+                                    });
+                                });
                             }
                         }
                     }
@@ -209,6 +219,19 @@ fn main() -> Result<()> {
                                             config.clone()
                                         });
                                 runtime::set_from_config(&fresh_config);
+
+                                // If a window was open, remove its monitor
+                                // before toggling (toggle closes it).
+                                #[cfg(target_os = "macos")]
+                                if current.is_some() {
+                                    if let Some(m) = click_monitor.take() {
+                                        platform::remove_click_outside_monitor(m);
+                                    }
+                                    if !runtime::show_in_app_switcher() {
+                                        platform::apply_app_switcher_policy(false);
+                                    }
+                                }
+
                                 current = toggle(
                                     cx,
                                     current.take(),
@@ -217,28 +240,23 @@ fn main() -> Result<()> {
                                     hint,
                                 )
                                 .await;
-                                // If a window was just opened, arm the grace
-                                // period so the focus-loss check doesn't fire
-                                // before the OS has delivered foreground focus.
+
+                                // Window just opened: install the click-outside
+                                // monitor so we know when to close it.
+                                #[cfg(target_os = "macos")]
+                                if current.is_some() {
+                                    outside_clicked.store(false, Ordering::Relaxed);
+                                    click_monitor = Some(
+                                        platform::install_click_outside_monitor(
+                                            Arc::clone(&outside_clicked),
+                                        ),
+                                    );
+                                }
+
+                                // Non-macOS: arm the grace period.
+                                #[cfg(not(target_os = "macos"))]
                                 if current.is_some() {
                                     just_opened = 4; // ~600 ms at 150 ms/poll
-
-                                    // macOS: window.activate_window() schedules
-                                    // makeKeyAndOrderFront: asynchronously via the
-                                    // executor, so activateIgnoringOtherApps: in
-                                    // toggle_window fires before the window is
-                                    // visible — macOS silently discards activation
-                                    // requests when there is no key window yet.
-                                    // Wait for the window to appear, then re-activate
-                                    // the application so NSApp.isActive becomes true
-                                    // and the focus-loss check works correctly.
-                                    #[cfg(target_os = "macos")]
-                                    {
-                                        cx.background_executor()
-                                            .timer(Duration::from_millis(50))
-                                            .await;
-                                        let _ = cx.update(|cx| cx.activate(true));
-                                    }
                                 }
                             }
                             TrayEvent::Quit => {
@@ -439,11 +457,6 @@ fn toggle_window(
         // `update` returns Err if the window has already been removed;
         // either way we're done with this handle.
         let _ = handle.update(cx, |_view, window, _cx| window.remove_window());
-        // Demote back to Accessory now that no modal is open.
-        #[cfg(target_os = "macos")]
-        if !runtime::show_in_app_switcher() {
-            platform::apply_app_switcher_policy(false);
-        }
         return None;
     }
 

--- a/crates/aura/src/platform.rs
+++ b/crates/aura/src/platform.rs
@@ -159,16 +159,61 @@ pub fn apply_app_switcher_policy(show: bool) {
 #[cfg(not(target_os = "macos"))]
 pub fn apply_app_switcher_policy(_show: bool) {}
 
-/// Returns whether the macOS application is currently the active (frontmost) app.
-/// Uses `NSApp.isActive` — the authoritative OS answer — rather than GPUI's
-/// internal window tracking, which can lag after activation-policy switches.
+// ── macOS click-outside monitor ──────────────────────────────────────────────
+//
+// Menu bar apps don't own keyboard/mouse focus after showing a panel —
+// macOS restricts activation stealing since Sonoma. The reliable way to
+// detect "user clicked in another app" is a global NSEvent monitor, which
+// fires for mouse-down events that go to any application OTHER than ours.
+// When the monitor fires we set an AtomicBool; the GPUI poll loop checks
+// that flag and closes the window instead of relying on NSApp.isActive.
+
+/// Opaque handle for a global NSEvent monitor. Returned by
+/// `install_click_outside_monitor` and must be passed to
+/// `remove_click_outside_monitor` when the window closes.
 #[cfg(target_os = "macos")]
-pub fn app_is_active() -> bool {
+pub struct ClickOutsideMonitor(cocoa::base::id);
+
+// SAFETY: the monitor object is only ever touched from the GPUI main thread.
+#[cfg(target_os = "macos")]
+unsafe impl Send for ClickOutsideMonitor {}
+
+/// Register a global mouse-down monitor. The `clicked` flag is set to `true`
+/// whenever the user clicks in any application other than Aura. Only fires
+/// for events that are NOT delivered to our own windows.
+#[cfg(target_os = "macos")]
+pub fn install_click_outside_monitor(
+    clicked: std::sync::Arc<std::sync::atomic::AtomicBool>,
+) -> ClickOutsideMonitor {
+    use block::ConcreteBlock;
+    use cocoa::base::id;
+    use objc::{class, msg_send, sel, sel_impl};
+
+    // NSEventMaskLeftMouseDown | NSEventMaskRightMouseDown | NSEventMaskOtherMouseDown
+    let mask: u64 = (1 << 1) | (1 << 3) | (1 << 25);
+
+    let block = ConcreteBlock::new(move |_event: id| {
+        clicked.store(true, std::sync::atomic::Ordering::Relaxed);
+    });
+    let block = block.copy();
+
+    let monitor: id = unsafe {
+        msg_send![class!(NSEvent),
+            addGlobalMonitorForEventsMatchingMask: mask
+            handler: &*block]
+    };
+
+    // Keep the block alive for as long as the monitor is installed.
+    std::mem::forget(block);
+    ClickOutsideMonitor(monitor)
+}
+
+/// Unregister and release a previously installed global monitor.
+#[cfg(target_os = "macos")]
+pub fn remove_click_outside_monitor(monitor: ClickOutsideMonitor) {
     use objc::{class, msg_send, sel, sel_impl};
     unsafe {
-        let app: cocoa::base::id = msg_send![class!(NSApplication), sharedApplication];
-        let active: cocoa::base::BOOL = msg_send![app, isActive];
-        active != cocoa::base::NO
+        let _: () = msg_send![class!(NSEvent), removeMonitor: monitor.0];
     }
 }
 

--- a/crates/aura/src/platform.rs
+++ b/crates/aura/src/platform.rs
@@ -1,3 +1,8 @@
+// The `objc` 0.2 crate's macros (msg_send!, class!, sel_impl!) emit an
+// internal `cargo-clippy` cfg that newer rustc/clippy treats as unknown.
+// The macros are third-party; suppress the lint rather than forking objc.
+#![allow(unexpected_cfgs)]
+
 //! Thin per-OS façade for the things Aura asks of the host: tweaking the
 //! macOS activation policy and asking the desktop to open a file/URL with
 //! the user's default handler.

--- a/crates/aura/src/work_area.rs
+++ b/crates/aura/src/work_area.rs
@@ -1,3 +1,7 @@
+// Same suppression as platform.rs — objc 0.2 macros emit an internal
+// `cargo-clippy` cfg that newer rustc/clippy flags as unexpected_cfgs.
+#![allow(unexpected_cfgs)]
+
 //! Available work-area detection — display rect minus reserved panels.
 //!
 //! Used in two places:


### PR DESCRIPTION
Fixes #16

## Problem

The modal closed automatically instead of waiting for the user to click outside. The previous approach called `activateIgnoringOtherApps:YES` to make `NSApp.isActive` reliable, but macOS Sonoma silently rejects programmatic activation for Accessory-policy apps. The window closed after the grace period regardless of user intent.

## Solution

Install a global `NSEvent` monitor when the modal opens. The monitor is registered with `NSEvent.addGlobalMonitorForEventsMatchingMask:handler:` for mouse-down events. It fires **only for events delivered to other applications** — clicks inside Aura's own window are never reported. When it fires, it sets an `AtomicBool`; the 150ms poll loop reads the flag and closes the window.

This is the standard macOS approach for transient panels (the same mechanism `NSPopover` uses internally). It requires no focus ownership and works correctly on all macOS versions.

## Changes

**`platform.rs`**
- Adds `ClickOutsideMonitor` (opaque handle, `Send`-safe wrapper around `id`)
- Adds `install_click_outside_monitor(Arc<AtomicBool>) -> ClickOutsideMonitor`
- Adds `remove_click_outside_monitor(ClickOutsideMonitor)`
- Removes `app_is_active()` (no longer needed)

**`main.rs`**
- On macOS: installs the monitor on window open, removes it on every close path (focus-loss dismiss and explicit toggle-close)
- Removes the 50ms delayed re-activate hack
- Removes the `just_opened` grace period on macOS (not needed without focus polling)
- Non-macOS platforms (Linux, Windows) retain the existing `cx.active_window()` path unchanged

**`Cargo.toml`**
- Adds `block = "0.1"` under `[target.'cfg(target_os = "macos")'.dependencies]` for Objective-C block creation

## Scope

macOS only. Linux and Windows behaviour is unchanged.