### PR TITLE
fix(macos): keep modal on top and stop button clicks from dismissing it

### DIFF
--- a/crates/aura/src/main.rs
+++ b/crates/aura/src/main.rs
@@ -137,20 +137,18 @@ fn main() -> Result<()> {
                 // "Show Aura" click: open if closed, close if open.
                 let mut current: Option<WindowHandle<AuraView>> = None;
 
-                // macOS: global NSEvent monitor that fires when the user
-                // clicks in any OTHER application. When it fires we set this
-                // flag; the poll loop checks it and closes the window.
-                // This avoids needing to steal focus — menu bar apps on
-                // modern macOS can't reliably do that programmatically.
+                // macOS: NSEvent global monitor flag. Accessory apps can't
+                // reliably set [NSApp mainWindow], which kills cx.active_window
+                // detection; the global monitor is the working alternative.
                 #[cfg(target_os = "macos")]
                 let outside_clicked = Arc::new(AtomicBool::new(false));
                 #[cfg(target_os = "macos")]
                 let mut click_monitor: Option<platform::ClickOutsideMonitor> = None;
 
-                // Grace-period counter for non-macOS platforms: skip
-                // focus-loss checks for this many poll intervals after
-                // opening the modal so Win32 / Wayland can deliver focus.
-                #[cfg(not(target_os = "macos"))]
+                // Grace-period counter: skip focus-loss checks for this many
+                // poll intervals after opening the modal so the platform
+                // can finish delivering focus / setting up the monitor before
+                // we start watching for losses.
                 let mut just_opened: u8 = 0;
 
                 loop {
@@ -159,24 +157,20 @@ fn main() -> Result<()> {
                     // them between short sleeps.
                     cx.background_executor().timer(MENU_POLL_INTERVAL).await;
 
-                    // Auto-close when the user clicks outside the modal.
-                    // macOS: a global NSEvent monitor flags outside clicks
-                    //   without needing focus ownership (reliable on Sonoma+).
-                    // Other platforms: cx.active_window() goes None when
-                    //   another app takes focus.
-                    // Skipped entirely when dismiss_on_focus_loss=false.
                     if runtime::dismiss_on_focus_loss() && current.is_some() {
-                        #[cfg(target_os = "macos")]
-                        let lost_focus =
-                            outside_clicked.load(Ordering::Relaxed);
-
-                        #[cfg(not(target_os = "macos"))]
                         let lost_focus = if just_opened > 0 {
                             just_opened -= 1;
                             false
                         } else {
-                            cx.update(|cx| cx.active_window().is_none())
-                                .unwrap_or(false)
+                            #[cfg(target_os = "macos")]
+                            {
+                                outside_clicked.load(Ordering::Relaxed)
+                            }
+                            #[cfg(not(target_os = "macos"))]
+                            {
+                                cx.update(|cx| cx.active_window().is_none())
+                                    .unwrap_or(false)
+                            }
                         };
 
                         if lost_focus {
@@ -220,8 +214,9 @@ fn main() -> Result<()> {
                                         });
                                 runtime::set_from_config(&fresh_config);
 
-                                // If a window was open, remove its monitor
-                                // before toggling (toggle closes it).
+                                // If a window was open, tear down its monitor
+                                // and demote the activation policy before the
+                                // toggle (which closes it).
                                 #[cfg(target_os = "macos")]
                                 if current.is_some() {
                                     if let Some(m) = click_monitor.take() {
@@ -241,22 +236,19 @@ fn main() -> Result<()> {
                                 )
                                 .await;
 
-                                // Window just opened: install the click-outside
-                                // monitor so we know when to close it.
-                                #[cfg(target_os = "macos")]
-                                if current.is_some() {
-                                    outside_clicked.store(false, Ordering::Relaxed);
-                                    click_monitor = Some(
-                                        platform::install_click_outside_monitor(
-                                            Arc::clone(&outside_clicked),
-                                        ),
-                                    );
-                                }
-
-                                // Non-macOS: arm the grace period.
-                                #[cfg(not(target_os = "macos"))]
                                 if current.is_some() {
                                     just_opened = 4; // ~600 ms at 150 ms/poll
+                                    // macOS: install the click-outside
+                                    // monitor for the new window.
+                                    #[cfg(target_os = "macos")]
+                                    {
+                                        outside_clicked.store(false, Ordering::Relaxed);
+                                        click_monitor = Some(
+                                            platform::install_click_outside_monitor(
+                                                Arc::clone(&outside_clicked),
+                                            ),
+                                        );
+                                    }
                                 }
                             }
                             TrayEvent::Quit => {
@@ -472,18 +464,23 @@ fn toggle_window(
     let bounds = compute_modal_bounds(cx, hint);
     // `display.show_in_app_switcher` controls whether the modal appears in
     // the OS's "where are my windows" surfaces — Cmd+Tab + Dock on macOS,
-    // Alt+Tab + taskbar on Windows, panel + window switcher on Linux. The
-    // process-wide macOS NSApp policy is applied separately at startup and
-    // on each refresh (see `platform::apply_app_switcher_policy`).
+    // Alt+Tab + taskbar on Windows, panel + window switcher on Linux.
     //
-    // - true  → WindowKind::Normal: regular app window (WS_EX_APPWINDOW on
-    //           Windows; default xdg_toplevel on Wayland). Visible in the
-    //           switcher.
-    // - false → WindowKind::PopUp: WS_EX_TOOLWINDOW on Windows, no taskbar
-    //           entry on most Linux DEs. The visible flash from the
-    //           taskbar animation goes away in this mode, which is the
-    //           reason we kept it the hard-coded default on Windows
-    //           historically.
+    // Linux / Windows:
+    //   - true  → WindowKind::Normal (xdg_toplevel / WS_EX_APPWINDOW).
+    //   - false → WindowKind::PopUp  (no taskbar entry, WS_EX_TOOLWINDOW).
+    //
+    // macOS: ALWAYS Normal. GPUI maps WindowKind::PopUp to NSPanel with
+    // NSWindowStyleMaskNonactivatingPanel, which deliberately prevents the
+    // window from becoming key. We need the window to be key so
+    // `cx.active_window()` can track focus (the focus-loss check below
+    // depends on this). What keeps Aura out of Cmd+Tab on macOS is the
+    // NSApplicationActivationPolicy — promoted to Regular only while the
+    // modal is open, demoted back to Accessory on close (see
+    // `platform::apply_app_switcher_policy` calls).
+    #[cfg(target_os = "macos")]
+    let kind = WindowKind::Normal;
+    #[cfg(not(target_os = "macos"))]
     let kind = if config.display.show_in_app_switcher {
         WindowKind::Normal
     } else {
@@ -498,6 +495,13 @@ fn toggle_window(
         // user tries to Detect Window Properties on the modal.
         app_id: Some("aura".into()),
         kind,
+        // On macOS, GPUI creates the window with NSTitled|NSFullSizeContentView
+        // even when titlebar:None. The native title-bar drag zone covers our
+        // header; with is_movable:true the OS handles drags there, which can
+        // route mouse events outside GPUI's queue. Disabling movability tells
+        // AppKit to forward those clicks to the content view instead, so the
+        // header buttons behave like normal content.
+        is_movable: false,
         ..Default::default()
     };
 
@@ -529,7 +533,17 @@ fn toggle_window(
                     window.activate_window();
                 });
             }
-            #[cfg(not(target_os = "windows"))]
+            #[cfg(target_os = "macos")]
+            {
+                let _ = handle.update(cx, |_, window, _| {
+                    // Raise above other apps' windows. GPUI's Normal kind sets
+                    // NSNormalWindowLevel, so without this the modal opens
+                    // behind whatever app the user was focused on.
+                    platform::raise_window_to_floating(window);
+                    window.activate_window();
+                });
+            }
+            #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
             {
                 let _ = handle.update(cx, |_, window, _| window.activate_window());
             }

--- a/crates/aura/src/platform.rs
+++ b/crates/aura/src/platform.rs
@@ -166,15 +166,19 @@ pub fn apply_app_switcher_policy(_show: bool) {}
 
 // ── macOS click-outside monitor ──────────────────────────────────────────────
 //
-// Menu bar apps don't own keyboard/mouse focus after showing a panel —
-// macOS restricts activation stealing since Sonoma. The reliable way to
-// detect "user clicked in another app" is a global NSEvent monitor, which
-// fires for mouse-down events that go to any application OTHER than ours.
-// When the monitor fires we set an AtomicBool; the GPUI poll loop checks
-// that flag and closes the window instead of relying on NSApp.isActive.
+// Accessory apps on macOS (LSUIElement/setActivationPolicy:.accessory) can't
+// reliably set the application's "main window" — `[NSApp mainWindow]` returns
+// nil even after we promote the policy to Regular and call activateIgnoringOtherApps.
+// That kills `cx.active_window()`-based focus-loss detection (it reads mainWindow).
+//
+// The reliable signal is an NSEvent global monitor, which fires only for
+// mouse-down events sent to OTHER applications. We pair it with
+// WindowKind::Normal (regular NSWindow rather than NonactivatingPanel) so
+// clicks delivered to our window aren't seen by the global monitor — that
+// avoids the false-positive on interactive elements we saw with the panel
+// kind.
 
-/// Opaque handle for a global NSEvent monitor. Returned by
-/// `install_click_outside_monitor` and must be passed to
+/// Opaque handle for a global NSEvent monitor. Pass it to
 /// `remove_click_outside_monitor` when the window closes.
 #[cfg(target_os = "macos")]
 pub struct ClickOutsideMonitor(cocoa::base::id);
@@ -184,8 +188,7 @@ pub struct ClickOutsideMonitor(cocoa::base::id);
 unsafe impl Send for ClickOutsideMonitor {}
 
 /// Register a global mouse-down monitor. The `clicked` flag is set to `true`
-/// whenever the user clicks in any application other than Aura. Only fires
-/// for events that are NOT delivered to our own windows.
+/// whenever the user clicks in any application other than Aura.
 #[cfg(target_os = "macos")]
 pub fn install_click_outside_monitor(
     clicked: std::sync::Arc<std::sync::atomic::AtomicBool>,
@@ -208,7 +211,6 @@ pub fn install_click_outside_monitor(
             handler: &*block]
     };
 
-    // Keep the block alive for as long as the monitor is installed.
     std::mem::forget(block);
     ClickOutsideMonitor(monitor)
 }
@@ -219,6 +221,33 @@ pub fn remove_click_outside_monitor(monitor: ClickOutsideMonitor) {
     use objc::{class, msg_send, sel, sel_impl};
     unsafe {
         let _: () = msg_send![class!(NSEvent), removeMonitor: monitor.0];
+    }
+}
+
+/// Promote the given window above other applications' windows by raising its
+/// NSWindow level. Required for menu-bar popovers: GPUI's `WindowKind::Normal`
+/// uses `NSNormalWindowLevel`, which leaves the modal behind whatever app the
+/// user was using when they clicked the tray icon.
+#[cfg(target_os = "macos")]
+pub fn raise_window_to_floating(window: &mut gpui::Window) {
+    use objc::{msg_send, sel, sel_impl};
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+
+    // NSFloatingWindowLevel = 3 — above normal windows but below menus/status.
+    const NS_FLOATING_WINDOW_LEVEL: i64 = 3;
+
+    let Ok(wh) = <gpui::Window as HasWindowHandle>::window_handle(window) else {
+        return;
+    };
+    let RawWindowHandle::AppKit(h) = wh.as_raw() else {
+        return;
+    };
+    unsafe {
+        let ns_view = h.ns_view.as_ptr() as cocoa::base::id;
+        let ns_window: cocoa::base::id = msg_send![ns_view, window];
+        if !ns_window.is_null() {
+            let _: () = msg_send![ns_window, setLevel: NS_FLOATING_WINDOW_LEVEL];
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #21 — on macOS the menu-bar modal was dismissing when the user clicked header buttons (settings / refresh / "...") and was opening behind the previously focused app.

Both stem from `WindowKind::PopUp` mapping to `NSPanel` + `NSWindowStyleMaskNonactivatingPanel` in GPUI. NonactivatingPanel never becomes key, so:

- Interactive-element clicks sometimes leave the app's `NSEvent` queue and trip our global click-outside monitor → spurious dismiss.
- `[NSApp mainWindow]` stays `nil`, so `cx.active_window()` cannot be used for focus tracking (PopUp also covered for the window-level concern, which we lose by changing kinds).

This PR:

- Switches the modal to `WindowKind::Normal` so it is a regular `NSWindow`; interactive clicks now flow through the standard event path and the global monitor no longer false-positives.
- Adds `platform::raise_window_to_floating` which sets `NSFloatingWindowLevel` on the `NSWindow` (reached via `raw_window_handle`) right after the window opens, so the modal sits above the previously focused app.
- Keeps `is_movable: false` so the native title-bar drag zone (still present because GPUI applies `NSTitled | NSFullSizeContentView` even with `titlebar: None`) forwards clicks to the content view rather than consuming them for a drag.
- Keeps the `NSEvent` global monitor as the focus-loss signal on macOS (Accessory apps still can't set `[NSApp mainWindow]`); Linux and Windows continue using `cx.active_window()`. The grace-period counter is unified across platforms.

## Test plan

- [x] `bash scripts/pre-pr.sh` — rustfmt / clippy / test / cargo_audit / build_release all PASS.
- [x] macOS, `show_in_app_switcher = false`: tray click → modal appears in front of the previously focused app, stays open after the loading spinner finishes, all header buttons (settings / refresh / "...") run their actions without dismissing the window.
- [x] macOS: clicking outside the modal (in another app) dismisses it as before.
- [ ] Linux/Windows: untouched code paths; CI build_release covers compile, focus-loss detection still uses `cx.active_window()`.