### PR TITLE
feature/forecast tab

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -196,5 +196,4 @@
 - Plugin authoring guide + example repo
 - Plugin registry (`aura plugin install <name>`)
 - Custom command agents (BYOA)
-- Cost alerts / budget warnings
 - macOS: Developer-ID codesign + notarization (needs Apple account)

--- a/README.md
+++ b/README.md
@@ -612,8 +612,8 @@ Next up
 
 - [x] Plugin authoring guide + example plugin (see `docs/plugin-authoring.md` and `plugins/hello/`)
 - [x] Plugin discovery (local scan of `~/.config/aura/plugins/`) + `aura plugin add|list|remove`
+- [ ] **Forecast tab** — project end-of-window usage (session, weekly, …) from the current burn rate, shown alongside each quota bar; rolls out per agent: Claude Code → Codex → Gemini. Design: [`docs/forecast-tab.md`](docs/forecast-tab.md)
 - [ ] Custom command agents (BYOA — Bring Your Own Agent via a shell command)
-- [ ] Cost alerts / budget warnings
 - [ ] Historical usage charts (daily / weekly trend in the modal)
 - [ ] Per-project usage breakdown (where agents expose project-scoped data)
 

--- a/crates/aura-core/src/quota/api.rs
+++ b/crates/aura-core/src/quota/api.rs
@@ -277,6 +277,7 @@ impl QuotaApi {
                 used_percentage: None,
                 used_tokens: Some(five_hour),
                 resets_at: Some(next_five_hour_reset(now)),
+                length_minutes: None,
             });
         }
         windows.push(QuotaWindow {
@@ -284,6 +285,7 @@ impl QuotaApi {
             used_percentage: None,
             used_tokens: Some(seven_day),
             resets_at: Some(next_weekly_reset(now)),
+            length_minutes: None,
         });
 
         Ok(QuotaSnapshot {
@@ -298,11 +300,21 @@ impl QuotaApi {
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 fn api_window(label: &str, w: &RawWindow) -> QuotaWindow {
+    // Claude Code's `/api/oauth/usage` doesn't expose window lengths, so we
+    // hardcode the closed set of windows the API actually returns.
+    let length_minutes = match label {
+        "Current session" => Some(5 * 60),
+        "Current week (all models)" | "Current week (Opus only)" | "Current week (Sonnet only)" => {
+            Some(7 * 24 * 60)
+        }
+        _ => None,
+    };
     QuotaWindow {
         label: label.to_string(),
         used_percentage: w.percentage(),
         used_tokens: None,
         resets_at: w.resets_at().and_then(parse_ts),
+        length_minutes,
     }
 }
 

--- a/crates/aura-core/src/quota/codex.rs
+++ b/crates/aura-core/src/quota/codex.rs
@@ -219,6 +219,7 @@ fn window_from(default_label: &str, w: &RawWindow) -> QuotaWindow {
         used_percentage: w.used_percent,
         used_tokens: None,
         resets_at: w.resets_at.and_then(unix_to_datetime),
+        length_minutes: w.window_minutes.and_then(|m| u32::try_from(m).ok()),
     }
 }
 

--- a/crates/aura-core/src/quota/forecast.rs
+++ b/crates/aura-core/src/quota/forecast.rs
@@ -1,0 +1,361 @@
+//! Forecasts where each quota window will end up if the current burn rate
+//! continues — see `docs/forecast-tab.md`.
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::{QuotaSnapshot, QuotaWindow};
+
+/// Below this elapsed fraction we don't extrapolate — too little signal.
+const INSUFFICIENT_BELOW: f64 = 0.05;
+
+/// Status badge keyed off the projected end-of-window percentage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ForecastStatus {
+    /// Projection stays under 90% — comfortably within the window.
+    Ok,
+    /// Projection is between 90% and 100% — likely to land near the cap.
+    Watch,
+    /// Projection exceeds 100% — current rate overshoots the window.
+    Overshoot,
+    /// Not enough elapsed time to project — show "warming up" placeholder.
+    Insufficient,
+}
+
+/// One row in the Forecast tab — mirrors a [`QuotaWindow`] but projected
+/// forward to `resets_at` at the current burn rate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForecastWindow {
+    pub label: String,
+    pub used_percentage_now: Option<f64>,
+    pub projected_percentage: Option<f64>,
+    pub projected_tokens: Option<u64>,
+    /// When linear extrapolation crosses 100%. `None` unless status is
+    /// `Overshoot`.
+    pub overshoot_at: Option<DateTime<Utc>>,
+    pub status: ForecastStatus,
+    pub resets_at: Option<DateTime<Utc>>,
+}
+
+/// A full set of forecasts — one per supported quota window.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForecastSnapshot {
+    pub windows: Vec<ForecastWindow>,
+    pub computed_at: DateTime<Utc>,
+    /// Free-form note (e.g. "session has 8 min elapsed") for an
+    /// `Insufficient` row, or other context.
+    pub note: Option<String>,
+}
+
+/// Project every supported window in `quota` forward to its `resets_at`
+/// assuming a uniform burn rate from the start of the window until `now`.
+pub fn forecast(quota: &QuotaSnapshot, now: DateTime<Utc>) -> ForecastSnapshot {
+    let windows = quota
+        .windows
+        .iter()
+        .filter_map(|w| project_window(w, now))
+        .collect();
+    ForecastSnapshot {
+        windows,
+        computed_at: now,
+        note: None,
+    }
+}
+
+/// Project a single window. Returns `None` for windows that don't have a
+/// known length (e.g. "Overage") or that lack the inputs we need.
+fn project_window(w: &QuotaWindow, now: DateTime<Utc>) -> Option<ForecastWindow> {
+    let length = window_length(w)?;
+    let resets_at = w.resets_at?;
+    let started_at = resets_at - length;
+
+    let elapsed = (now - started_at).num_milliseconds() as f64;
+    let total = length.num_milliseconds() as f64;
+    if total <= 0.0 {
+        return None;
+    }
+    let elapsed_fraction = (elapsed / total).clamp(0.0, 1.0);
+
+    // No activity yet (or zero percentage) — flat projection.
+    let used_pct = w.used_percentage.unwrap_or(0.0);
+
+    if elapsed_fraction < INSUFFICIENT_BELOW || used_pct <= 0.0 {
+        return Some(ForecastWindow {
+            label: w.label.clone(),
+            used_percentage_now: w.used_percentage,
+            projected_percentage: None,
+            projected_tokens: None,
+            overshoot_at: None,
+            status: ForecastStatus::Insufficient,
+            resets_at: w.resets_at,
+        });
+    }
+
+    let projected_pct = used_pct / elapsed_fraction;
+    let projected_tokens = w
+        .used_tokens
+        .map(|t| ((t as f64) / elapsed_fraction).round() as u64);
+
+    let status = if projected_pct > 100.0 {
+        ForecastStatus::Overshoot
+    } else if projected_pct >= 90.0 {
+        ForecastStatus::Watch
+    } else {
+        ForecastStatus::Ok
+    };
+
+    // Linear extrapolation: rate = used_pct / elapsed. Time to 100% from
+    // `started_at` is `100 / rate = elapsed * (100 / used_pct)`.
+    let overshoot_at = if status == ForecastStatus::Overshoot {
+        let ms_to_100 = (elapsed * (100.0 / used_pct)).round() as i64;
+        Some(started_at + Duration::milliseconds(ms_to_100))
+    } else {
+        None
+    };
+
+    Some(ForecastWindow {
+        label: w.label.clone(),
+        used_percentage_now: w.used_percentage,
+        projected_percentage: Some(projected_pct),
+        projected_tokens,
+        overshoot_at,
+        status,
+        resets_at: w.resets_at,
+    })
+}
+
+/// Resolve a window's length. Prefers `QuotaWindow.length_minutes` when the
+/// backend populates it (Codex, Claude Code API); falls back to a closed-set
+/// label map for the legacy path. Returns `None` for windows we deliberately
+/// skip (Overage) or for local-fallback labels that lack percentage data.
+fn window_length(w: &QuotaWindow) -> Option<Duration> {
+    if let Some(m) = w.length_minutes {
+        if m > 0 {
+            return Some(Duration::minutes(m as i64));
+        }
+    }
+    match w.label.as_str() {
+        "Current session" => Some(Duration::hours(5)),
+        "Current week (all models)" | "Current week (Opus only)" | "Current week (Sonnet only)" => {
+            Some(Duration::days(7))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::quota::{QuotaSnapshot, QuotaWindow};
+
+    fn window(label: &str, pct: Option<f64>, resets_in_hours: i64) -> QuotaWindow {
+        QuotaWindow {
+            label: label.to_string(),
+            used_percentage: pct,
+            used_tokens: None,
+            resets_at: Some(Utc::now() + Duration::hours(resets_in_hours)),
+            length_minutes: None,
+        }
+    }
+
+    /// 25% elapsed, 30% used → projects to 120% (overshoot).
+    #[test]
+    fn overshoot_when_pace_above_uniform() {
+        let now = Utc::now();
+        let resets_at = now + Duration::hours(4); // session: 1h elapsed of 5h = 20%
+        let w = QuotaWindow {
+            label: "Current session".to_string(),
+            used_percentage: Some(30.0),
+            used_tokens: None,
+            resets_at: Some(resets_at),
+            length_minutes: None,
+        };
+        let snap = QuotaSnapshot {
+            windows: vec![w],
+            ..Default::default()
+        };
+        let fc = forecast(&snap, now);
+        let proj = &fc.windows[0];
+        assert_eq!(proj.status, ForecastStatus::Overshoot);
+        let p = proj.projected_percentage.unwrap();
+        assert!((p - 150.0).abs() < 0.5, "expected ~150%, got {p}");
+        assert!(proj.overshoot_at.is_some());
+        // 100% is reached when used_pct hits 100, at rate 30%/h → 100/30 ≈ 3.33h
+        // from start, i.e. ~2.33h after `now`.
+        let over = proj.overshoot_at.unwrap();
+        let delta = (over - now).num_minutes();
+        assert!(
+            (130..=150).contains(&delta),
+            "expected overshoot ~2h20m out, got {delta}m"
+        );
+    }
+
+    /// 50% elapsed, 45% used → linear, lands ≈ 90% (Watch boundary).
+    #[test]
+    fn watch_band_around_100() {
+        let now = Utc::now();
+        let resets_at = now + Duration::hours(2) + Duration::minutes(30); // 2.5h elapsed of 5h
+        let w = QuotaWindow {
+            label: "Current session".to_string(),
+            used_percentage: Some(45.0),
+            used_tokens: None,
+            resets_at: Some(resets_at),
+            length_minutes: None,
+        };
+        let snap = QuotaSnapshot {
+            windows: vec![w],
+            ..Default::default()
+        };
+        let fc = forecast(&snap, now);
+        let proj = &fc.windows[0];
+        let p = proj.projected_percentage.unwrap();
+        assert!((p - 90.0).abs() < 1.0, "expected ~90%, got {p}");
+        assert_eq!(proj.status, ForecastStatus::Watch);
+    }
+
+    /// 75% elapsed, 30% used → projects ≈ 40% (Ok).
+    #[test]
+    fn ok_status_when_under_pace() {
+        let now = Utc::now();
+        let resets_at = now + Duration::hours(1) + Duration::minutes(15); // 3.75h elapsed of 5h
+        let w = QuotaWindow {
+            label: "Current session".to_string(),
+            used_percentage: Some(30.0),
+            used_tokens: None,
+            resets_at: Some(resets_at),
+            length_minutes: None,
+        };
+        let snap = QuotaSnapshot {
+            windows: vec![w],
+            ..Default::default()
+        };
+        let fc = forecast(&snap, now);
+        let proj = &fc.windows[0];
+        let p = proj.projected_percentage.unwrap();
+        assert!((p - 40.0).abs() < 0.5, "expected ~40%, got {p}");
+        assert_eq!(proj.status, ForecastStatus::Ok);
+        assert!(proj.overshoot_at.is_none());
+    }
+
+    /// < 5% elapsed → Insufficient regardless of usage.
+    #[test]
+    fn insufficient_when_barely_started() {
+        let now = Utc::now();
+        // 5h session window, 5min elapsed = 1.6%
+        let resets_at = now + Duration::hours(5) - Duration::minutes(5);
+        let w = QuotaWindow {
+            label: "Current session".to_string(),
+            used_percentage: Some(10.0),
+            used_tokens: None,
+            resets_at: Some(resets_at),
+            length_minutes: None,
+        };
+        let snap = QuotaSnapshot {
+            windows: vec![w],
+            ..Default::default()
+        };
+        let fc = forecast(&snap, now);
+        let proj = &fc.windows[0];
+        assert_eq!(proj.status, ForecastStatus::Insufficient);
+        assert!(proj.projected_percentage.is_none());
+    }
+
+    /// 0% used → Insufficient ("no activity yet").
+    #[test]
+    fn insufficient_when_no_usage() {
+        let now = Utc::now();
+        let w = QuotaWindow {
+            label: "Current session".to_string(),
+            used_percentage: Some(0.0),
+            used_tokens: None,
+            resets_at: Some(now + Duration::hours(2)),
+            length_minutes: None,
+        };
+        let snap = QuotaSnapshot {
+            windows: vec![w],
+            ..Default::default()
+        };
+        let fc = forecast(&snap, now);
+        assert_eq!(fc.windows[0].status, ForecastStatus::Insufficient);
+    }
+
+    /// Empty snapshot → empty forecast (no panic).
+    #[test]
+    fn empty_snapshot_yields_empty_forecast() {
+        let fc = forecast(&QuotaSnapshot::default(), Utc::now());
+        assert!(fc.windows.is_empty());
+    }
+
+    /// Unknown labels (Overage, local-fallback) are dropped.
+    #[test]
+    fn unknown_labels_are_skipped() {
+        let snap = QuotaSnapshot {
+            windows: vec![
+                window("Overage", Some(50.0), 1),
+                window("Current session (local est.)", Some(50.0), 1),
+                window("Current session", Some(50.0), 1),
+            ],
+            ..Default::default()
+        };
+        let fc = forecast(&snap, Utc::now());
+        assert_eq!(fc.windows.len(), 1);
+        assert_eq!(fc.windows[0].label, "Current session");
+    }
+
+    /// Codex labels carry a `· 5h` / `· weekly` suffix and don't match the
+    /// Claude-Code label allowlist — they must project off `length_minutes`.
+    #[test]
+    fn codex_labels_project_off_length_minutes() {
+        let now = Utc::now();
+        let w = QuotaWindow {
+            label: "Primary · 5h".to_string(),
+            used_percentage: Some(30.0),
+            used_tokens: None,
+            // 1h elapsed of 5h → projects to 150% (overshoot).
+            resets_at: Some(now + Duration::hours(4)),
+            length_minutes: Some(5 * 60),
+        };
+        let snap = QuotaSnapshot {
+            windows: vec![w],
+            ..Default::default()
+        };
+        let fc = forecast(&snap, now);
+        assert_eq!(fc.windows.len(), 1, "Codex window should be projectable");
+        let p = fc.windows[0].projected_percentage.unwrap();
+        assert!((p - 150.0).abs() < 0.5, "expected ~150%, got {p}");
+        assert_eq!(fc.windows[0].status, ForecastStatus::Overshoot);
+    }
+
+    /// 25% / 50% / 75% elapsed at 20% used: projection scales linearly.
+    #[test]
+    fn linear_extrapolation_scales_correctly() {
+        let now = Utc::now();
+        // Session window, 5h length.
+        let cases = [
+            (Duration::minutes(75), 80.0),  // 1.25h elapsed = 25% → 80% projected
+            (Duration::minutes(150), 40.0), // 2.5h elapsed = 50% → 40% projected
+            (Duration::minutes(225), 80.0 / 3.0), // 3.75h elapsed = 75% → ~26.7%
+        ];
+        for (elapsed, expected) in cases {
+            let resets_at = now + Duration::hours(5) - elapsed;
+            let w = QuotaWindow {
+                label: "Current session".to_string(),
+                used_percentage: Some(20.0),
+                used_tokens: None,
+                resets_at: Some(resets_at),
+                length_minutes: None,
+            };
+            let snap = QuotaSnapshot {
+                windows: vec![w],
+                ..Default::default()
+            };
+            let fc = forecast(&snap, now);
+            let p = fc.windows[0].projected_percentage.unwrap();
+            assert!(
+                (p - expected).abs() < 0.5,
+                "elapsed {:?}: expected ~{expected}, got {p}",
+                elapsed
+            );
+        }
+    }
+}

--- a/crates/aura-core/src/quota/gemini.rs
+++ b/crates/aura-core/src/quota/gemini.rs
@@ -126,12 +126,14 @@ impl GeminiQuota {
                 used_percentage: None,
                 used_tokens: Some(session_tokens),
                 resets_at: None,
+                length_minutes: None,
             },
             QuotaWindow {
                 label: "Last 7 days".to_string(),
                 used_percentage: None,
                 used_tokens: Some(seven_day_tokens),
                 resets_at: None,
+                length_minutes: None,
             },
         ];
 

--- a/crates/aura-core/src/quota/mod.rs
+++ b/crates/aura-core/src/quota/mod.rs
@@ -7,11 +7,13 @@
 
 mod api;
 mod codex;
+pub mod forecast;
 mod gemini;
 mod oauth;
 
 pub use api::{QuotaApi, QuotaSource};
 pub use codex::CodexQuota;
+pub use forecast::{forecast, ForecastSnapshot, ForecastStatus, ForecastWindow};
 pub use gemini::GeminiQuota;
 
 use chrono::{DateTime, Utc};
@@ -26,6 +28,12 @@ pub struct QuotaWindow {
     /// Absolute input+output tokens used in the window (may be approximate).
     pub used_tokens: Option<u64>,
     pub resets_at: Option<DateTime<Utc>>,
+    /// Total length of this window. Forecasts use it to derive `started_at`
+    /// from `resets_at`. `None` for backends that don't expose it (e.g. the
+    /// local-fallback estimator); such windows are skipped by the Forecast
+    /// tab.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub length_minutes: Option<u32>,
 }
 
 /// A snapshot of the user's current quota state.

--- a/crates/aura/src/app.rs
+++ b/crates/aura/src/app.rs
@@ -3,7 +3,10 @@ use std::{cell::Cell, path::PathBuf, rc::Rc, time::Duration};
 use aura_core::{
     config::{AgentConfig, AgentKind, AppConfig, PluginConfig},
     plugin::{PluginContent, PluginPanel, PluginRunner, PluginSection},
-    quota::{CodexQuota, GeminiQuota, QuotaApi, QuotaSnapshot, QuotaSource, QuotaWindow},
+    quota::{
+        forecast, CodexQuota, ForecastSnapshot, ForecastStatus, ForecastWindow, GeminiQuota,
+        QuotaApi, QuotaSnapshot, QuotaSource, QuotaWindow,
+    },
     reader::{make_reader, Period, UsageSnapshot},
     state::AppState,
     theme::Theme,
@@ -37,6 +40,7 @@ enum Mode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AgentSection {
     Quota,
+    Forecast,
     Summary,
     Models,
 }
@@ -45,6 +49,7 @@ impl AgentSection {
     fn label(self) -> &'static str {
         match self {
             Self::Quota => "Quota",
+            Self::Forecast => "Forecast",
             Self::Summary => "Summary",
             Self::Models => "Models",
         }
@@ -53,6 +58,7 @@ impl AgentSection {
     fn id(self) -> &'static str {
         match self {
             Self::Quota => "quota",
+            Self::Forecast => "forecast",
             Self::Summary => "summary",
             Self::Models => "models",
         }
@@ -63,7 +69,7 @@ impl AgentSection {
     /// the period pills don't apply.
     fn uses_period(self) -> bool {
         match self {
-            Self::Quota => false,
+            Self::Quota | Self::Forecast => false,
             Self::Summary | Self::Models => true,
         }
     }
@@ -90,6 +96,7 @@ pub struct AuraView {
 
     snapshot: Option<UsageSnapshot>,
     quota: Option<QuotaSnapshot>,
+    forecast: Option<ForecastSnapshot>,
     /// Indexed by plugin name.
     plugin_panels: Vec<(String, PluginPanel)>,
 
@@ -128,6 +135,7 @@ struct RefreshResult {
     fallback_profile: Option<String>,
     snapshot: Option<UsageSnapshot>,
     quota: Option<QuotaSnapshot>,
+    forecast: Option<ForecastSnapshot>,
     plugin_panels: Vec<(String, PluginPanel)>,
     error: Option<String>,
 }
@@ -171,6 +179,7 @@ impl AuraView {
             active_plugin_section: None,
             snapshot: None,
             quota: None,
+            forecast: None,
             plugin_panels: Vec::new(),
             show_more_modal: false,
             show_settings_panel: false,
@@ -237,6 +246,7 @@ impl AuraView {
         }
         self.snapshot = result.snapshot;
         self.quota = result.quota;
+        self.forecast = result.forecast;
         self.plugin_panels = result.plugin_panels;
         self.error = result.error;
 
@@ -321,6 +331,7 @@ fn do_refresh(
                 fallback_profile: None,
                 snapshot: None,
                 quota: None,
+                forecast: None,
                 plugin_panels: Vec::new(),
                 error: Some(format!("Could not reload config: {e}")),
             };
@@ -350,6 +361,7 @@ fn do_refresh(
             fallback_profile,
             snapshot: None,
             quota: None,
+            forecast: None,
             plugin_panels: Vec::new(),
             error: Some(format!("Profile `{resolved_profile}` not found in config")),
         };
@@ -373,6 +385,10 @@ fn do_refresh(
         AgentKind::Gemini => GeminiQuota::new(agent_path).snapshot(),
     });
 
+    // Forecast piggybacks on the just-loaded quota snapshot. Same refresh
+    // cadence, no extra I/O.
+    let forecast = quota.as_ref().map(|q| forecast::forecast(q, Utc::now()));
+
     // Plugins: each runs as a subprocess with `--period` passed through.
     let plugin_panels = config
         .plugins
@@ -386,6 +402,7 @@ fn do_refresh(
         fallback_profile,
         snapshot,
         quota,
+        forecast,
         plugin_panels,
         error,
     }
@@ -1027,6 +1044,7 @@ impl AuraView {
             Mode::Agent => {
                 let sections = [
                     AgentSection::Quota,
+                    AgentSection::Forecast,
                     AgentSection::Summary,
                     AgentSection::Models,
                 ];
@@ -1110,6 +1128,12 @@ impl AuraView {
                     AgentSection::Quota => {
                         render_quota(&self.theme, self.quota.as_ref(), accent, self.spinner_frame)
                     }
+                    AgentSection::Forecast => render_forecast(
+                        &self.theme,
+                        self.forecast.as_ref(),
+                        accent,
+                        self.spinner_frame,
+                    ),
                     AgentSection::Summary => match self.snapshot.as_ref() {
                         Some(snap) => render_summary(&self.theme, snap),
                         None => render_loading(&self.theme, self.spinner_frame),
@@ -1444,6 +1468,178 @@ fn format_reset(ts: DateTime<Utc>) -> String {
         let date = local.format_localized("%b %-d", locale).to_string();
         format!("{date}, {time}")
     }
+}
+
+// ── Forecast (projected end-of-window usage at current burn rate) ───────────
+
+fn render_forecast(
+    theme: &Theme,
+    forecast: Option<&ForecastSnapshot>,
+    accent: u32,
+    spinner_frame: usize,
+) -> AnyElement {
+    let Some(forecast) = forecast else {
+        return render_loading(theme, spinner_frame);
+    };
+
+    let mut col = div().flex().flex_col().px_4().py_3().gap_3();
+
+    if forecast.windows.is_empty() {
+        col = col.child(
+            div()
+                .px_3()
+                .py_2()
+                .rounded_md()
+                .border_1()
+                .border_color(rgb(theme.colors.border))
+                .bg(rgb(theme.colors.surface))
+                .text_color(rgb(theme.colors.text_dim))
+                .text_xs()
+                .child(
+                    "No forecast available — quota source did not report any projectable windows.",
+                ),
+        );
+    } else {
+        for w in &forecast.windows {
+            col = col.child(render_forecast_window(theme, w, accent));
+        }
+    }
+
+    col.into_any_element()
+}
+
+fn render_forecast_window(theme: &Theme, w: &ForecastWindow, accent: u32) -> impl IntoElement {
+    let (badge_text, badge_color) = match w.status {
+        ForecastStatus::Ok => ("On track", accent),
+        ForecastStatus::Watch => ("Watch", theme.colors.warning),
+        ForecastStatus::Overshoot => ("Overshoot", theme.colors.error),
+        ForecastStatus::Insufficient => ("—", theme.colors.text_dim),
+    };
+
+    let header = div()
+        .flex()
+        .flex_row()
+        .items_center()
+        .justify_between()
+        .child(
+            div()
+                .text_color(rgb(theme.colors.text))
+                .child(SharedString::from(w.label.clone())),
+        )
+        .child(
+            div()
+                .px_2()
+                .py_0p5()
+                .rounded_md()
+                .border_1()
+                .border_color(rgb(badge_color))
+                .text_xs()
+                .text_color(rgb(badge_color))
+                .child(SharedString::from(badge_text)),
+        );
+
+    let mut card = div()
+        .flex()
+        .flex_col()
+        .gap_2()
+        .px_3()
+        .py_3()
+        .bg(rgb(theme.colors.surface))
+        .rounded_md()
+        .border_1()
+        .border_color(rgb(theme.colors.border))
+        .child(header);
+
+    if w.status == ForecastStatus::Insufficient {
+        card = card.child(
+            div()
+                .text_xs()
+                .text_color(rgb(theme.colors.text_dim))
+                .child("warming up — check back in a few minutes"),
+        );
+        return card;
+    }
+
+    // Two-segment bar: solid `used_now` + translucent `projected delta`.
+    // Cap both at 100%; overshoot gets a separate marker on the right.
+    let used_now = w.used_percentage_now.unwrap_or(0.0).clamp(0.0, 100.0) as f32;
+    let projected = w
+        .projected_percentage
+        .unwrap_or(used_now as f64)
+        .clamp(0.0, 100.0) as f32;
+    let used_frac = used_now / 100.0;
+    let projected_extra_frac = ((projected - used_now).max(0.0)) / 100.0;
+    let overflowed = w.projected_percentage.map(|p| p > 100.0).unwrap_or(false);
+
+    // Show "current / projected" so the user sees both the live value and
+    // where the bar is heading.
+    let projected_label = match (w.used_percentage_now, w.projected_percentage) {
+        (Some(now_pct), Some(proj_pct)) => format!("{:.0}% / {:.0}%", now_pct, proj_pct),
+        (Some(now_pct), None) => format!("{:.0}% / —", now_pct),
+        (None, Some(proj_pct)) => format!("— / {:.0}%", proj_pct),
+        (None, None) => "—".to_string(),
+    };
+
+    // Build the bar: a track, then a flex row of two filled segments.
+    let bar = div()
+        .h(px(8.0))
+        .flex_1()
+        .bg(rgb(theme.colors.surface_hi))
+        .rounded_md()
+        .flex()
+        .flex_row()
+        .child(
+            div()
+                .h(px(8.0))
+                .w(gpui::relative(used_frac))
+                .bg(rgb(accent))
+                .rounded_md(),
+        )
+        .child(
+            div()
+                .h(px(8.0))
+                .w(gpui::relative(projected_extra_frac))
+                .bg(rgba((accent << 8) | 0x66))
+                .rounded_md(),
+        );
+
+    let mut bar_row = div().flex().flex_row().items_center().gap_2().child(bar);
+
+    if overflowed {
+        bar_row = bar_row.child(
+            div()
+                .text_xs()
+                .text_color(rgb(theme.colors.error))
+                .child("↗"),
+        );
+    }
+
+    bar_row = bar_row.child(
+        div()
+            .text_xs()
+            .text_color(rgb(theme.colors.text))
+            .child(SharedString::from(projected_label)),
+    );
+    card = card.child(bar_row);
+
+    let subtext = match w.status {
+        ForecastStatus::Overshoot => w
+            .overshoot_at
+            .map(|t| format!("Will hit 100% at {}", format_reset(t)))
+            .unwrap_or_else(|| "Projected to overshoot".to_string()),
+        _ => match w.resets_at {
+            Some(t) => format!("Projected at reset {}", format_reset(t)),
+            None => "Projected at reset".to_string(),
+        },
+    };
+    card = card.child(
+        div()
+            .text_xs()
+            .text_color(rgb(theme.colors.text_dim))
+            .child(SharedString::from(subtext)),
+    );
+
+    card
 }
 
 // ── Summary (the old "Overview" — stat-card grid) ────────────────────────────

--- a/docs/forecast-tab.md
+++ b/docs/forecast-tab.md
@@ -1,0 +1,253 @@
+---
+title: Forecast tab
+status: design
+version: 0.1.0
+last_updated: 2026-05-27
+last_verified: 2026-05-27
+source_refs:
+  - crates/aura-core/src/quota/mod.rs
+  - crates/aura-core/src/quota/api.rs
+  - crates/aura-core/src/reader/mod.rs
+  - crates/aura/src/app.rs
+owner: "@rfluid"
+tags: [forecast, quota, roadmap, design]
+---
+
+# Forecast tab
+
+## Problem
+
+The Quota tab tells the user **what they have used so far** in each
+rate-limit window (5h session, 7d weekly, 7d Opus, 7d Sonnet, overage).
+It does not tell them **whether the current burn rate will exhaust the
+window before it resets**. A user halfway through a 5h session at 60%
+used has no way to know, without manual math, that they are on track to
+overshoot.
+
+The Quota tab answers _"where am I?"_ — the Forecast tab answers
+_"where am I headed?"_.
+
+## Scope
+
+A new modal tab named **Forecast**, sitting alongside Quota / Summary /
+Models / Plugins. For every rate-limit window the Quota tab renders,
+the Forecast tab renders a matching projection:
+
+- **Projected end-of-window %** — what `used_percentage` is expected to
+  be at `resets_at` if the current pace continues.
+- **Projected absolute tokens** (when the source provides counts).
+- **Overshoot indicator** — green / amber / red badge keyed off the
+  projected percentage (`< 90%`, `90–100%`, `> 100%`).
+- **Time until overshoot** (red windows only) — when the linear
+  extrapolation crosses 100%.
+
+Rollout is per agent:
+
+1. **Claude Code** (first) — has the richest data: API-reported
+   `utilization` + JSONL-derived per-timestamp token counts.
+2. **Codex** — second.
+3. **Gemini** — third.
+
+Out of scope for v1:
+
+- Forecast for plugin-supplied panels.
+- Cost (dollar) forecasts — v1 projects token usage only. The same
+  engine can later multiply by per-model pricing once that data is
+  modeled; tracked as a follow-up below.
+- Anomaly / spike detection — only smoothed rate extrapolation.
+- Proactive alerts / notifications when a projection crosses
+  100% — Forecast v1 is a passive tab. A tray-icon badge / desktop
+  notification is a natural follow-up once the engine is proven.
+
+## Non-goals
+
+- Predicting future _content_ of usage (which model, which project).
+- Replacing the Quota tab — Forecast is additive.
+- Sub-minute precision — windows are hours-to-days; the user only needs
+  to know "you will / will not overshoot".
+
+## Design
+
+### Forecasting model
+
+For each `QuotaWindow`, we know:
+
+- `used_percentage` (or `used_tokens`) at "now".
+- `resets_at` — when the window rolls over.
+- The **window length** (5h, 7d, …) — currently _not_ in `QuotaWindow`;
+  see [Required plumbing](#required-plumbing).
+
+From window length and `resets_at` we derive `started_at = resets_at -
+length`. Then:
+
+```text
+elapsed_fraction  = (now - started_at) / length          # 0.0 … 1.0
+projected_at_end  = used_now / elapsed_fraction          # linear extrapolation
+```
+
+Edge cases:
+
+- `elapsed_fraction < 0.05` (window barely started) — display
+  "insufficient signal" instead of a wild projection.
+- `elapsed_fraction > 0.95` — projection ≈ current value; flag as
+  "near reset" rather than forecasting.
+- `used_now == 0` — show "no activity yet".
+
+v1 uses **plain linear extrapolation** (uniform pace). Two follow-ups
+are scoped but explicitly deferred to keep v1 shippable:
+
+- **Recency-weighted rate** — sum tokens in the last _N_ minutes from
+  `UsageSnapshot.daily_tokens` / session JSONL and divide by _N_,
+  instead of treating the whole elapsed window as uniform. Better
+  for bursty workloads; needs a tunable window. The relevant data is
+  already in `UsageSnapshot` (see
+  `crates/aura-core/src/reader/mod.rs:93`).
+- **Confidence band** — derive a min/max projection from rate variance
+  across recent sample buckets; render as a faded range on the bar.
+
+### Data shape
+
+New types in `crates/aura-core/src/quota/forecast.rs`:
+
+```rust
+pub struct ForecastWindow {
+    pub label: String,                   // mirrors QuotaWindow.label
+    pub used_percentage_now: Option<f64>,
+    pub projected_percentage: Option<f64>,
+    pub projected_tokens: Option<u64>,
+    pub overshoot_at: Option<DateTime<Utc>>, // when projection crosses 100%
+    pub status: ForecastStatus,          // Ok | Watch | Overshoot | Insufficient
+    pub resets_at: Option<DateTime<Utc>>,
+}
+
+pub struct ForecastSnapshot {
+    pub windows: Vec<ForecastWindow>,
+    pub computed_at: DateTime<Utc>,
+    pub note: Option<String>,            // e.g. "session has 8 min elapsed"
+}
+
+pub enum ForecastStatus { Ok, Watch, Overshoot, Insufficient }
+```
+
+A pure function takes a `QuotaSnapshot` plus optional `UsageSnapshot`
+(for recency weighting in a later version) and returns a
+`ForecastSnapshot`:
+
+```rust
+pub fn forecast(
+    quota: &QuotaSnapshot,
+    now: DateTime<Utc>,
+) -> ForecastSnapshot;
+```
+
+Agent-agnostic — both Codex and Gemini already feed a `QuotaSnapshot`
+from their own quota providers, so the same function serves all three.
+
+### Required plumbing
+
+`QuotaWindow` (`crates/aura-core/src/quota/mod.rs:22`) does **not**
+currently expose a window length or start time. The
+`/api/oauth/usage` body only carries `utilization` and `resets_at` /
+`resetsAt` (see `crates/aura-core/src/quota/api.rs:78`). Three options;
+recommendation is **(a)**:
+
+(a) **Derive length from label / window kind**. The five labels are a
+closed set ("Current session" → 5h, "Current week …" → 7d, "Overage"
+→ skip). Encode the mapping in `forecast.rs` and keep `QuotaWindow`
+unchanged. Pro: zero plumbing. Con: brittle if Anthropic adds a new
+window label.
+
+(b) Add `length: Option<chrono::Duration>` to `QuotaWindow` and have
+each backend (`QuotaApi`, `CodexQuota`, `GeminiQuota`) populate it.
+Cleaner, but touches three providers and the wire format.
+
+(c) Add a `WindowKind` enum (`Session5h`, `Week7d`, `Week7dOpus`,
+`Week7dSonnet`, `Overage`) alongside `label`. Best long-term but
+the largest diff.
+
+Start with **(a)**, migrate to **(c)** when a second consumer needs
+window length (e.g. the budget-warnings roadmap item).
+
+### UI
+
+Tab plumbing (all in `crates/aura/src/app.rs`):
+
+1. Add `Forecast` variant to `AgentSection` enum at line 38.
+2. Add label (`"Forecast"`) and id (`"forecast"`) at lines 44–59.
+3. Add to the tab array in `render_tab_row()` at line 1028.
+4. Add render dispatch in `render_body()` at line 1109 →
+   `render_forecast(cx)`.
+5. Implement `render_forecast()` mirroring `render_quota()`
+   (line 1223) and `render_quota_window()` (line 1333), but for
+   `ForecastWindow` instead of `QuotaWindow`.
+
+Visual:
+
+- One row per window, same vertical rhythm as the Quota tab.
+- The progress bar shows **two segments**: solid (used now) +
+  hashed/translucent (projected delta to `projected_percentage`).
+  Capped at 100%; anything beyond renders as an overflow marker.
+- Right-aligned: `projected_percentage` and the status badge.
+- Subtext: `"Projected at reset"` or `"Will hit 100% at 14:32"` for
+  overshoots.
+- `Insufficient` rows render a muted placeholder ("warming up — check
+  back in a few minutes") so the tab is never empty on a fresh session.
+
+### Refresh integration
+
+In `crates/aura/src/app.rs`:
+
+1. Add `forecast: Option<ForecastSnapshot>` to `RefreshResult` (line
+   122).
+2. In `do_refresh()` (line 295), after the quota snapshot loads, call
+   `forecast::forecast(&quota, Utc::now())`.
+3. In `apply_refresh_result()` (line 224), assign to `self.forecast`.
+4. Same refresh button / hot-reload behavior — no new code paths.
+
+No background timer in v1: the forecast is recomputed only on
+modal-open / refresh-click / profile-switch / period-change, matching
+how Quota itself refreshes today. If users want a "live" forecast we
+can add a 60s tick later.
+
+## Rollout
+
+### Phase 1 — Claude Code (target: same PR)
+
+- Add `forecast` module under `crates/aura-core/src/quota/`.
+- Wire up `Forecast` tab and `render_forecast()`.
+- Hook into `RefreshResult` / `do_refresh()`.
+- Tests in `crates/aura-core/src/quota/forecast.rs`:
+  - linear extrapolation at 25%, 50%, 75% elapsed
+  - `Insufficient` when elapsed < 5%
+  - `Overshoot` + `overshoot_at` correctness
+  - empty `QuotaSnapshot` → empty `ForecastSnapshot` (no panic)
+
+### Phase 2 — Codex
+
+- Verify Codex's `QuotaSnapshot` populates `resets_at` and percentages
+  in the same shape (it should — same `QuotaWindow` type).
+- Confirm the label-→-length map in `forecast.rs` covers Codex's
+  window labels; extend if Codex uses different strings.
+- No UI changes — agent-agnostic dispatch already works.
+
+### Phase 3 — Gemini
+
+- Same as Phase 2 for Gemini.
+- After this lands, the **Forecast tab** roadmap item closes.
+
+## Open questions
+
+- **Do Codex / Gemini even have meaningful rate-limit windows today?**
+  If their `QuotaSnapshot` is currently `Unavailable`, the Forecast tab
+  for those agents will just show "no quota source". That is fine —
+  it tracks the Quota tab's behavior.
+- **Should Forecast pre-empt the Quota tab when the user is about to
+  overshoot?** Out of scope for v1; a tray-icon badge / desktop
+  notification when a projection crosses 100% is the natural
+  follow-up once the engine is proven.
+- **Do we want a "history" sparkline of past forecasts vs. actuals?**
+  Useful for tuning the model, but adds storage. Defer.
+
+## Tracking
+
+Roadmap entry: [`README.md` → Roadmap → Next up → Forecast tab](../README.md#roadmap).

--- a/docs/goblin-mode.md
+++ b/docs/goblin-mode.md
@@ -1,0 +1,364 @@
+---
+title: Goblin Mode (easter egg)
+status: design
+version: 0.1.0
+last_updated: 2026-05-27
+last_verified: 2026-05-27
+source_refs:
+  - crates/aura-core/src/config.rs
+  - crates/aura/src/app.rs
+  - crates/aura/src/format.rs
+  - docs/forecast-tab.md
+owner: "@rfluid"
+tags: [easter-egg, ui, lexicon, design]
+---
+
+# Goblin Mode (easter egg)
+
+## Problem
+
+Every user-facing string in the modal — tab labels, empty states,
+loading copy, status badges, projection blurbs — is hard-coded inline
+in `crates/aura/src/app.rs` and (for tokens / costs) `format.rs`.
+Adding a single alt-tone variant (let alone iterating on it) means
+hunting through ~76 KB of view code.
+
+We want a config-gated alternate persona — codename **Goblin Mode** —
+that swaps the polite default copy for unhinged, slop-laced,
+profanity-flecked variants. The trigger is a single boolean in
+`config.toml`; flipping it back restores the normal copy without a
+restart.
+
+This is also the right moment to centralize UI copy: even without the
+easter egg, having one place to read every string the modal renders
+makes future localization / theming / a11y review trivial.
+
+## Scope
+
+Replace **the user-facing copy** of the modal — not the layout, not
+the data, not the colors. Everything Goblin Mode touches is a string
+the user reads.
+
+In scope:
+
+- **Tab labels**: `Quota`, `Summary`, `Models`, `Plugins`,
+  `Forecast` (added by [[forecast-tab]] — see
+  [Dependency](#dependency-forecast-tab-first)).
+- **Status badges & enum-mapped copy**: `ForecastStatus`
+  (`Ok` / `Watch` / `Overshoot` / `Insufficient`), `Subscription:`,
+  `Resets <when>`, period pills (`all` / `7d` / `30d`).
+- **Empty / loading / error states**: `Loading…`, `No quota data
+  available.`, `No plugins configured`, `No plugin selected`,
+  `warming up — check back in a few minutes` (forecast),
+  generic error banner copy.
+- **More-menu entries**: `Open config file`, `Themes`, future
+  Settings/Refresh labels.
+- **Forecast-tab subtext**: `Projected at reset`, `Will hit 100%
+  at HH:MM`.
+
+Out of scope for v1:
+
+- **Plugin-supplied strings.** Plugins ship their own copy via JSON
+  IPC; we don't rewrite their output. If a plugin wants in, it can
+  read the active persona from a future env var (`AURA_PERSONA`)
+  itself.
+- **Agent/profile names, plugin display names.** User-authored config
+  values are sacred.
+- **Numbers, dates, paths, error details.** Goblin Mode wraps the
+  prose around them; it does not mangle data.
+- **Localization.** The lexicon is structurally ready for it, but v1
+  ships English only — both personas.
+- **Sound effects, animations, ASCII art.** Tempting, but out of
+  scope — text-only.
+
+## Non-goals
+
+- Hiding the easter egg. It's a documented config field with a clear
+  name. We don't want users flipping it on by accident, but we also
+  don't want a "find the secret" treasure hunt — that ages badly and
+  invites support tickets we can't reproduce.
+- Toning the persona down per-string. A persona is a whole vibe; if a
+  given line is too much for a user, they turn the persona off.
+- Multiple personas in v1. Architecture supports it (see
+  [Lexicon shape](#lexicon-shape)); shipping it means writing a
+  second variant lexicon plus a config enum. Defer.
+
+## Design
+
+### Trigger / config
+
+Add one field under `[display]` in `crates/aura-core/src/config.rs`:
+
+```toml
+[display]
+# Swap the modal's UI copy for an aggressive / unhinged variant.
+# Default false. Toggling reloads on the next refresh — no restart.
+goblin_mode = false
+```
+
+```rust
+// crates/aura-core/src/config.rs — DisplayConfig
+#[serde(default)]
+pub goblin_mode: bool,
+```
+
+`Default` returns `false`. Hot-reload piggy-backs on the existing
+config refresh path (same code path as `dismiss_on_focus_loss`,
+`window_chrome`, etc.) — no new infrastructure.
+
+**Why a bool, not an enum.** v1 ships one alt persona. When a second
+lands, migrate to `persona: PersonaKind` with `#[serde(default)]` and
+a `From<bool>` shim so old configs keep working for one release
+cycle, then drop the bool.
+
+### Lexicon shape
+
+New module `crates/aura-core/src/lexicon.rs`:
+
+```rust
+pub struct Lexicon {
+    // Tabs
+    pub tab_quota: &'static str,
+    pub tab_summary: &'static str,
+    pub tab_models: &'static str,
+    pub tab_plugins: &'static str,
+    pub tab_forecast: &'static str,
+
+    // Forecast status badges
+    pub forecast_ok: &'static str,
+    pub forecast_watch: &'static str,
+    pub forecast_overshoot: &'static str,
+    pub forecast_insufficient: &'static str,
+    pub forecast_projected_at_reset: &'static str,
+    pub forecast_will_hit_100_fmt: fn(time: &str) -> String,
+    pub forecast_warming_up: &'static str,
+
+    // Empty / loading / error
+    pub loading: &'static str,
+    pub no_quota_data: &'static str,
+    pub no_plugins_configured: &'static str,
+    pub no_plugin_selected: &'static str,
+    pub error_banner_prefix: &'static str,
+
+    // Quota row chrome
+    pub subscription_fmt: fn(sub: &str) -> String,
+    pub resets_fmt: fn(when: &str) -> String,
+
+    // More menu
+    pub menu_open_config: &'static str,
+    pub menu_themes: &'static str,
+
+    // Period pills
+    pub period_all: &'static str,
+    pub period_7d: &'static str,
+    pub period_30d: &'static str,
+}
+
+pub const POLITE: Lexicon = Lexicon { /* current copy, verbatim */ };
+pub const GOBLIN: Lexicon = Lexicon { /* see drafts below */ };
+
+pub fn pick(goblin_mode: bool) -> &'static Lexicon {
+    if goblin_mode { &GOBLIN } else { &POLITE }
+}
+```
+
+A few entries are `fn` rather than `&'static str` so persona-specific
+formatting (different word order, extra glyphs, capitalization quirks)
+stays inside the lexicon instead of leaking into view code.
+
+**Why one flat struct instead of a trait + two impls.** A struct is
+trivially `const` and can live in `aura-core` with zero runtime cost.
+A trait would force `dyn Lexicon` (slower) or generic plumbing
+through the view layer (uglier). The struct is also the
+nearly-mechanical refactor: every site that used a string literal
+becomes `lex.<field>`.
+
+### Persona drafts
+
+Voice rules for `GOBLIN`:
+
+- **Tonal target**: gremlin energy. Tired, sarcastic, mildly hostile,
+  occasionally affectionate toward the user. Think a friend roasting
+  your coding habits.
+- **Profanity**: allowed but rationed. `damn`, `hell`, `crap`, `bs`,
+  `shit` are fair game; harder slurs and anything targeting protected
+  classes are not. Never aimed _at the user_.
+- **Length**: don't blow up the layout. Goblin copy must fit the same
+  visual budget as the polite copy (tab labels stay one word; status
+  badges stay short).
+- **Data sanctity**: numbers, dates, paths render exactly as they do
+  in `POLITE`. Goblin Mode never makes the user re-derive a value.
+
+Working drafts (final pass during impl; treat these as direction, not
+spec):
+
+| Field | Polite | Goblin |
+|---|---|---|
+| `tab_quota` | Quota | Damage |
+| `tab_summary` | Summary | The Bill |
+| `tab_models` | Models | Slop Vendors |
+| `tab_plugins` | Plugins | Hangers-on |
+| `tab_forecast` | Forecast | Doom |
+| `forecast_ok` | OK | Fine, whatever |
+| `forecast_watch` | Watch | Bruh |
+| `forecast_overshoot` | Overshoot | Cooked |
+| `forecast_insufficient` | Insufficient | Idk yet |
+| `forecast_projected_at_reset` | Projected at reset | What you'll burn |
+| `forecast_will_hit_100_fmt(t)` | Will hit 100% at {t} | Goose is cooked at {t} |
+| `forecast_warming_up` | warming up — check back in a few minutes | give it a minute, jeez |
+| `loading` | Loading… | hold on damn |
+| `no_quota_data` | No quota data available. | Nothing. Empty. Dry. |
+| `no_plugins_configured` | No plugins configured | No hangers-on |
+| `no_plugin_selected` | No plugin selected | Pick one, coward |
+| `subscription_fmt(s)` | Subscription: {s} | Paying for: {s} |
+| `resets_fmt(w)` | Resets {w} | Wipes {w} |
+| `menu_open_config` | Open config file | Crack open the config |
+| `menu_themes` | Themes | Paint job |
+| `period_all` | all | the whole damn time |
+| `period_7d` | 7d | last week |
+| `period_30d` | 30d | this month-ish |
+
+Period pills are tight on width; if `the whole damn time` overflows
+in practice, fall back to `forever` / `week` / `month` — verify in
+the browser-equivalent render pass during impl.
+
+### Wiring sites
+
+Sites that today use a literal need to read from the active lexicon
+instead. Cataloged from `app.rs` / `format.rs` at time of writing
+(line numbers will drift — re-grep at impl time):
+
+1. `AgentSection::label()` — `app.rs:45` — return `lex.tab_*`. After
+   forecast lands, the new `AgentSection::Forecast` arm joins the
+   same match.
+2. Mode pill `("Plugins", …)` — `app.rs:934` — read `lex.tab_plugins`.
+3. Loading copy — `app.rs:1218` — `lex.loading`.
+4. `Subscription: {sub}` — `app.rs:1241` — `lex.subscription_fmt`.
+5. `No quota data available.` — `app.rs:1261` — `lex.no_quota_data`.
+6. `Resets {label}` — `app.rs:1405` — `lex.resets_fmt`.
+7. `No plugins configured` — `app.rs:879` — `lex.no_plugins_configured`.
+8. `No plugin selected` — `app.rs:1153` — `lex.no_plugin_selected`.
+9. `Open config file` — `app.rs:1968` — `lex.menu_open_config`.
+10. `Themes` — `app.rs:1990` — `lex.menu_themes`.
+11. Forecast strings — added by [[forecast-tab]]; wire to lexicon at
+    creation time, not in a follow-up pass (see
+    [Dependency](#dependency-forecast-tab-first)).
+
+`AuraView` reads the active lexicon once per render via
+`lexicon::pick(self.config.display.goblin_mode)`. No new state field —
+the config is already on `self`.
+
+### Hot reload
+
+The existing refresh-button / hot-reload path already re-parses
+`config.toml` (see `app.rs:295` `do_refresh()` and the
+`apply_refresh_result()` callsite). `goblin_mode` rides that bus for
+free — the next render picks up `&GOBLIN` instead of `&POLITE`. No
+window recreate, no restart.
+
+### Safety rails
+
+- **Test fixtures stay polite.** Snapshot / golden tests assert
+  against `POLITE` only. Goblin's strings have a smaller, dedicated
+  test (the per-field length budget; see below).
+- **Length budget test.** Unit test in `lexicon.rs`: every
+  `GOBLIN` entry whose `POLITE` counterpart is ≤ N chars must also be
+  ≤ N + 8 (or whatever the layout tolerates — tune during impl).
+  Stops drift where Goblin copy quietly breaks the tab row.
+- **Profanity boundary test.** Tiny deny-list (slurs, protected-class
+  targeting) checked against every `GOBLIN` string at compile time
+  via a `const fn` or a `#[test]`. Cheap, catches accidents during
+  PRs.
+- **Screenshot-safe default.** `goblin_mode = false` is the only
+  documented default; the README / docs screenshots always show
+  `POLITE`.
+
+## Dependency: Forecast tab first
+
+[[forecast-tab]] (`docs/forecast-tab.md`) adds:
+
+- `AgentSection::Forecast` (new enum variant + `label()` arm).
+- `ForecastStatus { Ok, Watch, Overshoot, Insufficient }`.
+- Subtext strings: `Projected at reset`, `Will hit 100% at HH:MM`,
+  `warming up — check back in a few minutes`.
+
+All of those are baked into the Goblin lexicon above. **Forecast
+ships first**, with strings hard-coded in the natural way; Goblin
+Mode is the immediate follow-up PR that:
+
+1. Lands `lexicon.rs` and the `display.goblin_mode` config field.
+2. Refactors every catalogued site (including the brand-new Forecast
+   sites) to read from the lexicon.
+3. Ships `POLITE` (verbatim current copy) + `GOBLIN` (drafts above).
+
+Doing it in this order means the Forecast PR isn't held up reviewing
+two unrelated concerns at once, and the Goblin PR is a single
+mechanical refactor + one new module — easy to review, easy to revert.
+
+After Goblin lands, the project rule becomes: **new user-facing
+string ⇒ new `Lexicon` field, in both personas, same PR.** Add a
+short note to `docs/ui-design.md` so contributors see it.
+
+## Rollout
+
+### Phase 0 — Forecast tab lands
+
+Tracked separately in [[forecast-tab]]. Goblin work does not start
+until Forecast is in `main`.
+
+### Phase 1 — Lexicon scaffolding
+
+- Add `lexicon.rs` with the `Lexicon` struct and `POLITE` constant
+  matching today's copy verbatim (no behavior change).
+- Add `display.goblin_mode: bool` to `DisplayConfig` with
+  `#[serde(default)]`.
+- Refactor every site in the [Wiring sites](#wiring-sites) catalog
+  to read from `lexicon::pick(...)`. Diff should be 1:1 — same
+  rendered strings, no visual change with `goblin_mode = false`.
+- Tests: confirm existing snapshot / golden tests still pass
+  unchanged.
+
+### Phase 2 — Goblin persona
+
+- Add `GOBLIN` constant with drafts from the table above
+  (finalize wording during PR review).
+- Length-budget test.
+- Profanity-boundary test.
+- Docs: append a short `## Goblin Mode` section to
+  `docs/configuration.md` documenting the flag, with a one-line
+  warning about tone.
+
+### Phase 3 — Field & polish
+
+- Internal dogfood for a week. Adjust copy where Goblin lines
+  overflow, fall flat, or punch down instead of sideways.
+- Decide whether v2 needs a second persona (`persona: PersonaKind`)
+  or whether one alt is enough. Captured in
+  [Open questions](#open-questions).
+
+## Open questions
+
+- **Naming.** "Goblin Mode" is the working codename. Alternatives
+  considered: `feral_mode`, `cursed_mode`, `slop_mode`. Codename and
+  config-field name don't have to match — e.g. ship as `goblin_mode`
+  in config but refer to the persona as "Feral" in UI/docs. Defer
+  until Phase 2 PR.
+- **Plugin opt-in.** Should plugins receive `AURA_PERSONA=goblin` so
+  their JSON output can match the host vibe? Cheap to add; defer
+  until a plugin actually asks.
+- **Per-tab opt-out.** Could imagine `goblin_mode_except = ["Quota"]`
+  for users who want chaos everywhere _except_ the screen they
+  screenshot for receipts. Almost certainly YAGNI — the global
+  toggle is the receipts.
+- **Tray-icon copy.** The tray tooltip / menu items are platform
+  code (`crates/aura/src/tray.rs`, `platform.rs`). v1 scope is the
+  modal only; tray comes after if Phase 3 dogfood shows the contrast
+  is jarring.
+- **Theme coupling.** Should Goblin Mode also nudge accent colors
+  (e.g. force a punchier accent)? Out of scope — theme is its own
+  knob. Users can stack them.
+
+## Tracking
+
+Roadmap entry: add under "Backlog / under consideration" once Forecast
+is in flight — single bullet, link to this doc.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,7 +44,6 @@ _Goal: working widget for Claude Code usage with RTK Gains plugin_
 
 - Custom command agents (BYOA — Bring Your Own Agent via a shell command)
 - Plugin registry (`aura plugin install <name>`)
-- Cost alerts / budget warnings
 - Per-project usage breakdown (if agents expose project-scoped data)
 - Historical usage charts (daily/weekly trend in the modal)
 - **In-modal config editor page** — a settings page inside the modal that


### PR DESCRIPTION
- **docs(roadmap): plan Forecast tab; drop redundant cost-alerts entry**
- **docs(roadmap): plan Goblin Mode easter-egg lexicon**
- **feat(forecast): add Forecast tab projecting end-of-window usage**
