### PR TITLE
feature/goblin mode

### DIFF
--- a/crates/aura-core/src/config.rs
+++ b/crates/aura-core/src/config.rs
@@ -138,6 +138,11 @@ pub struct DisplayConfig {
     /// Ignored when [`Self::window_chrome`] is true (auto-fit is off then).
     #[serde(default)]
     pub max_height: Option<u32>,
+    /// Swap the modal's user-facing copy for an aggressive / unhinged variant
+    /// ("Goblin Mode"). Default false. Toggling reloads on the next refresh —
+    /// no restart. See `docs/goblin-mode.md`.
+    #[serde(default)]
+    pub goblin_mode: bool,
 }
 
 impl Default for DisplayConfig {
@@ -150,6 +155,7 @@ impl Default for DisplayConfig {
             dismiss_on_focus_loss: true,
             window_chrome: false,
             max_height: None,
+            goblin_mode: false,
         }
     }
 }

--- a/crates/aura-core/src/lexicon.rs
+++ b/crates/aura-core/src/lexicon.rs
@@ -1,0 +1,279 @@
+//! User-facing UI copy for the modal, swappable at runtime via
+//! `display.goblin_mode`. See `docs/goblin-mode.md` for the design rationale.
+//!
+//! Adding a new user-facing string ⇒ new `Lexicon` field, in **both**
+//! personas, in the same PR.
+
+/// All user-facing strings the modal renders. Two const variants live at
+/// module scope (`POLITE` and `GOBLIN`); the active one is selected per
+/// render via [`pick`].
+///
+/// A handful of fields are `fn` rather than `&'static str` so persona-
+/// specific word order or extra glyphs around the data (subscription tier,
+/// reset time, …) stays inside the lexicon instead of leaking into view
+/// code.
+pub struct Lexicon {
+    // ── Tabs ────────────────────────────────────────────────────────────────
+    pub tab_quota: &'static str,
+    pub tab_summary: &'static str,
+    pub tab_models: &'static str,
+    pub tab_plugins: &'static str,
+    pub tab_forecast: &'static str,
+
+    // ── Forecast status badges & subtext ───────────────────────────────────
+    pub forecast_ok: &'static str,
+    pub forecast_watch: &'static str,
+    pub forecast_overshoot: &'static str,
+    pub forecast_insufficient: &'static str,
+    pub forecast_projected_at_reset: &'static str,
+    pub forecast_will_hit_100_fmt: fn(time: &str) -> String,
+    pub forecast_warming_up: &'static str,
+
+    // ── Empty / loading ─────────────────────────────────────────────────────
+    pub loading: &'static str,
+    pub no_quota_data: &'static str,
+    pub no_plugins_configured: &'static str,
+    pub no_plugin_selected: &'static str,
+
+    // ── Quota row chrome ────────────────────────────────────────────────────
+    pub subscription_fmt: fn(sub: &str) -> String,
+    pub resets_fmt: fn(when: &str) -> String,
+
+    // ── More menu ───────────────────────────────────────────────────────────
+    pub menu_open_config: &'static str,
+    pub menu_themes: &'static str,
+
+    // ── Period pills ────────────────────────────────────────────────────────
+    pub period_all: &'static str,
+    pub period_7d: &'static str,
+    pub period_30d: &'static str,
+}
+
+fn polite_subscription(sub: &str) -> String {
+    format!("Subscription: {sub}")
+}
+fn polite_resets(when: &str) -> String {
+    format!("Resets {when}")
+}
+fn polite_will_hit_100(time: &str) -> String {
+    format!("Will hit 100% at {time}")
+}
+
+fn goblin_subscription(sub: &str) -> String {
+    format!("Paying for: {sub}")
+}
+fn goblin_resets(when: &str) -> String {
+    format!("Wipes {when}")
+}
+fn goblin_will_hit_100(time: &str) -> String {
+    format!("Goose is cooked at {time}")
+}
+
+/// Default voice. Verbatim copy of what the modal renders today — flipping
+/// `goblin_mode` off must produce an identical UI.
+pub const POLITE: Lexicon = Lexicon {
+    tab_quota: "Quota",
+    tab_summary: "Summary",
+    tab_models: "Models",
+    tab_plugins: "Plugins",
+    tab_forecast: "Forecast",
+
+    forecast_ok: "On track",
+    forecast_watch: "Watch",
+    forecast_overshoot: "Overshoot",
+    forecast_insufficient: "—",
+    forecast_projected_at_reset: "Projected at reset",
+    forecast_will_hit_100_fmt: polite_will_hit_100,
+    forecast_warming_up: "warming up — check back in a few minutes",
+
+    loading: "Loading…",
+    no_quota_data: "No quota data available.",
+    no_plugins_configured: "No plugins configured",
+    no_plugin_selected: "No plugin selected",
+
+    subscription_fmt: polite_subscription,
+    resets_fmt: polite_resets,
+
+    menu_open_config: "Open config file",
+    menu_themes: "Themes",
+
+    period_all: "All time",
+    period_7d: "Last 7 days",
+    period_30d: "Last 30 days",
+};
+
+/// Alt persona — gremlin energy, mildly hostile, never aimed at the user.
+/// See `docs/goblin-mode.md` for the voice rules.
+pub const GOBLIN: Lexicon = Lexicon {
+    tab_quota: "Damage",
+    tab_summary: "The Bill",
+    tab_models: "Slop Vendors",
+    tab_plugins: "Hangers-on",
+    tab_forecast: "Doom",
+
+    forecast_ok: "Fine, whatever",
+    forecast_watch: "Bruh",
+    forecast_overshoot: "Cooked",
+    forecast_insufficient: "Idk yet",
+    forecast_projected_at_reset: "What you'll burn",
+    forecast_will_hit_100_fmt: goblin_will_hit_100,
+    forecast_warming_up: "give it a minute, jeez",
+
+    loading: "hold on damn",
+    no_quota_data: "Nothing. Empty. Dry.",
+    no_plugins_configured: "No hangers-on",
+    no_plugin_selected: "Pick one, coward",
+
+    subscription_fmt: goblin_subscription,
+    resets_fmt: goblin_resets,
+
+    menu_open_config: "Crack open the config",
+    menu_themes: "Paint job",
+
+    period_all: "the whole damn time",
+    period_7d: "last week",
+    period_30d: "this month-ish",
+};
+
+/// Resolve the active lexicon from the `goblin_mode` config flag.
+pub fn pick(goblin_mode: bool) -> &'static Lexicon {
+    if goblin_mode {
+        &GOBLIN
+    } else {
+        &POLITE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// (field name, polite value, goblin value) for every `&'static str` entry
+    /// in the lexicon. Used by the length-budget / profanity tests so adding a
+    /// new field forces a same-PR update here.
+    fn pairs() -> Vec<(&'static str, &'static str, &'static str)> {
+        vec![
+            ("tab_quota", POLITE.tab_quota, GOBLIN.tab_quota),
+            ("tab_summary", POLITE.tab_summary, GOBLIN.tab_summary),
+            ("tab_models", POLITE.tab_models, GOBLIN.tab_models),
+            ("tab_plugins", POLITE.tab_plugins, GOBLIN.tab_plugins),
+            ("tab_forecast", POLITE.tab_forecast, GOBLIN.tab_forecast),
+            ("forecast_ok", POLITE.forecast_ok, GOBLIN.forecast_ok),
+            (
+                "forecast_watch",
+                POLITE.forecast_watch,
+                GOBLIN.forecast_watch,
+            ),
+            (
+                "forecast_overshoot",
+                POLITE.forecast_overshoot,
+                GOBLIN.forecast_overshoot,
+            ),
+            (
+                "forecast_insufficient",
+                POLITE.forecast_insufficient,
+                GOBLIN.forecast_insufficient,
+            ),
+            (
+                "forecast_projected_at_reset",
+                POLITE.forecast_projected_at_reset,
+                GOBLIN.forecast_projected_at_reset,
+            ),
+            (
+                "forecast_warming_up",
+                POLITE.forecast_warming_up,
+                GOBLIN.forecast_warming_up,
+            ),
+            ("loading", POLITE.loading, GOBLIN.loading),
+            ("no_quota_data", POLITE.no_quota_data, GOBLIN.no_quota_data),
+            (
+                "no_plugins_configured",
+                POLITE.no_plugins_configured,
+                GOBLIN.no_plugins_configured,
+            ),
+            (
+                "no_plugin_selected",
+                POLITE.no_plugin_selected,
+                GOBLIN.no_plugin_selected,
+            ),
+            (
+                "menu_open_config",
+                POLITE.menu_open_config,
+                GOBLIN.menu_open_config,
+            ),
+            ("menu_themes", POLITE.menu_themes, GOBLIN.menu_themes),
+            ("period_all", POLITE.period_all, GOBLIN.period_all),
+            ("period_7d", POLITE.period_7d, GOBLIN.period_7d),
+            ("period_30d", POLITE.period_30d, GOBLIN.period_30d),
+        ]
+    }
+
+    /// Goblin entries must not exceed their polite counterpart by more than
+    /// ~12 chars. Tab labels and badges share a flex row that wraps awkwardly
+    /// past that — see `docs/goblin-mode.md` §Safety rails.
+    #[test]
+    fn goblin_length_budget() {
+        const BUDGET: usize = 12;
+        for (label, polite, goblin) in pairs() {
+            let p = polite.chars().count();
+            let g = goblin.chars().count();
+            assert!(
+                g <= p + BUDGET,
+                "{label}: goblin ({g} chars) exceeds polite ({p} chars) + {BUDGET}",
+            );
+        }
+    }
+
+    /// Persona is allowed to be coarse; targeted slurs and protected-class
+    /// shots are not. Reviewers extend the deny-list as new patterns surface.
+    #[test]
+    fn goblin_profanity_boundary() {
+        // Intentionally minimal — extend in review when a real pattern lands.
+        // Kept here so that any future GOBLIN edit that accidentally includes
+        // one of these substrings fails CI rather than shipping.
+        const BANNED: &[&str] = &[
+            // No live entries yet. Adding examples here would put slurs in
+            // the source tree; reviewers add specific tokens when they
+            // catch one in a PR.
+        ];
+        for (label, _, goblin) in pairs() {
+            let g = goblin.to_lowercase();
+            for needle in BANNED {
+                assert!(
+                    !g.contains(needle),
+                    "{label}: goblin string contains banned token {needle:?}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn pick_matches_flag() {
+        // `const` items don't have a stable address (each reference may create
+        // a fresh copy in the binary), so compare a tagging field instead of
+        // pointers.
+        assert_eq!(pick(false).tab_quota, POLITE.tab_quota);
+        assert_eq!(pick(true).tab_quota, GOBLIN.tab_quota);
+        assert_ne!(POLITE.tab_quota, GOBLIN.tab_quota);
+    }
+
+    #[test]
+    fn polite_formatters_match_legacy_copy() {
+        assert_eq!((POLITE.subscription_fmt)("pro"), "Subscription: pro");
+        assert_eq!((POLITE.resets_fmt)("in 3h"), "Resets in 3h");
+        assert_eq!(
+            (POLITE.forecast_will_hit_100_fmt)("5pm"),
+            "Will hit 100% at 5pm",
+        );
+    }
+
+    #[test]
+    fn goblin_formatters_use_persona_words() {
+        assert_eq!((GOBLIN.subscription_fmt)("pro"), "Paying for: pro");
+        assert_eq!((GOBLIN.resets_fmt)("in 3h"), "Wipes in 3h");
+        assert_eq!(
+            (GOBLIN.forecast_will_hit_100_fmt)("5pm"),
+            "Goose is cooked at 5pm",
+        );
+    }
+}

--- a/crates/aura-core/src/lib.rs
+++ b/crates/aura-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod lexicon;
 pub mod plugin;
 pub mod quota;
 pub mod reader;

--- a/crates/aura/src/app.rs
+++ b/crates/aura/src/app.rs
@@ -2,6 +2,7 @@ use std::{cell::Cell, path::PathBuf, rc::Rc, time::Duration};
 
 use aura_core::{
     config::{AgentConfig, AgentKind, AppConfig, PluginConfig},
+    lexicon::{self, Lexicon},
     plugin::{PluginContent, PluginPanel, PluginRunner, PluginSection},
     quota::{
         forecast, CodexQuota, ForecastSnapshot, ForecastStatus, ForecastWindow, GeminiQuota,
@@ -46,12 +47,12 @@ enum AgentSection {
 }
 
 impl AgentSection {
-    fn label(self) -> &'static str {
+    fn label(self, lex: &Lexicon) -> &'static str {
         match self {
-            Self::Quota => "Quota",
-            Self::Forecast => "Forecast",
-            Self::Summary => "Summary",
-            Self::Models => "Models",
+            Self::Quota => lex.tab_quota,
+            Self::Forecast => lex.tab_forecast,
+            Self::Summary => lex.tab_summary,
+            Self::Models => lex.tab_models,
         }
     }
 
@@ -890,10 +891,11 @@ impl AuraView {
 
     fn render_plugin_pills(&self, cx: &mut Context<Self>) -> AnyElement {
         if self.config.plugins.is_empty() {
+            let lex = lexicon::pick(self.config.display.goblin_mode);
             return div()
                 .text_xs()
                 .text_color(rgb(self.theme.colors.text_dim))
-                .child("No plugins configured")
+                .child(lex.no_plugins_configured)
                 .into_any_element();
         }
         let mut picker = div()
@@ -946,9 +948,10 @@ impl AuraView {
     }
 
     fn render_mode_toggle(&self, cx: &mut Context<Self>) -> AnyElement {
+        let lex = lexicon::pick(self.config.display.goblin_mode);
         let modes = [
             ("Agents", Mode::Agent, "mode-agent"),
-            ("Plugins", Mode::Plugin, "mode-plugin"),
+            (lex.tab_plugins, Mode::Plugin, "mode-plugin"),
         ];
         // `flex_shrink_0` keeps the toggle visible when the sibling pill row
         // overflows and scrolls.
@@ -980,10 +983,11 @@ impl AuraView {
     }
 
     fn render_period_row(&self, cx: &mut Context<Self>) -> AnyElement {
+        let lex = lexicon::pick(self.config.display.goblin_mode);
         let periods = [
-            ("All time", Period::AllTime, "period-all"),
-            ("Last 7 days", Period::Last7Days, "period-7"),
-            ("Last 30 days", Period::Last30Days, "period-30"),
+            (lex.period_all, Period::AllTime, "period-all"),
+            (lex.period_7d, Period::Last7Days, "period-7"),
+            (lex.period_30d, Period::Last30Days, "period-30"),
         ];
 
         // Selected filter background uses the active agent's (or plugin's)
@@ -1040,6 +1044,7 @@ impl AuraView {
             .border_color(rgb(self.theme.colors.border))
             .bg(rgb(self.theme.colors.surface));
 
+        let lex = lexicon::pick(self.config.display.goblin_mode);
         match self.mode {
             Mode::Agent => {
                 let sections = [
@@ -1062,7 +1067,7 @@ impl AuraView {
                                     .border_color(rgb(accent))
                             })
                             .when(!active, |d| d.text_color(rgb(self.theme.colors.text_dim)))
-                            .child(s.label())
+                            .child(s.label(lex))
                             .on_click(cx.listener(move |view, _: &ClickEvent, _, cx| {
                                 view.set_agent_section(s, cx);
                             })),
@@ -1101,6 +1106,7 @@ impl AuraView {
     }
 
     fn render_body(&self, _cx: &mut Context<Self>) -> AnyElement {
+        let lex = lexicon::pick(self.config.display.goblin_mode);
         let inner: AnyElement = if let Some(err) = &self.error {
             div()
                 .flex()
@@ -1120,27 +1126,32 @@ impl AuraView {
             // agent/plugin/period produced and show a clean loading state.
             // Otherwise switching from Claude → Codex (etc.) flashes the
             // outgoing profile's numbers under the new tab.
-            render_loading(&self.theme, self.spinner_frame)
+            render_loading(&self.theme, lex, self.spinner_frame)
         } else {
             let accent = self.current_accent();
             match self.mode {
                 Mode::Agent => match self.active_agent_section {
-                    AgentSection::Quota => {
-                        render_quota(&self.theme, self.quota.as_ref(), accent, self.spinner_frame)
-                    }
+                    AgentSection::Quota => render_quota(
+                        &self.theme,
+                        lex,
+                        self.quota.as_ref(),
+                        accent,
+                        self.spinner_frame,
+                    ),
                     AgentSection::Forecast => render_forecast(
                         &self.theme,
+                        lex,
                         self.forecast.as_ref(),
                         accent,
                         self.spinner_frame,
                     ),
                     AgentSection::Summary => match self.snapshot.as_ref() {
                         Some(snap) => render_summary(&self.theme, snap),
-                        None => render_loading(&self.theme, self.spinner_frame),
+                        None => render_loading(&self.theme, lex, self.spinner_frame),
                     },
                     AgentSection::Models => match self.snapshot.as_ref() {
                         Some(snap) => render_models(&self.theme, snap, accent),
-                        None => render_loading(&self.theme, self.spinner_frame),
+                        None => render_loading(&self.theme, lex, self.spinner_frame),
                     },
                 },
                 Mode::Plugin => self.render_plugin_body(),
@@ -1163,6 +1174,7 @@ impl AuraView {
     }
 
     fn render_plugin_body(&self) -> AnyElement {
+        let lex = lexicon::pick(self.config.display.goblin_mode);
         let Some(panel) = self.current_plugin_panel() else {
             return div()
                 .flex()
@@ -1174,7 +1186,7 @@ impl AuraView {
                 .child(
                     div()
                         .text_color(rgb(self.theme.colors.text_dim))
-                        .child("No plugin selected"),
+                        .child(lex.no_plugin_selected),
                 )
                 .into_any_element();
         };
@@ -1199,7 +1211,7 @@ impl AuraView {
         let section = panel.section(section_id).or_else(|| panel.sections.first());
         match section {
             Some(s) => render_plugin_section(&self.theme, s, self.current_accent()),
-            None => render_loading(&self.theme, self.spinner_frame),
+            None => render_loading(&self.theme, lex, self.spinner_frame),
         }
     }
 }
@@ -1210,7 +1222,7 @@ impl AuraView {
 /// height of two quota windows (label + progress bar + resets row) so the
 /// modal barely resizes when the initial fetch completes — fewer visible
 /// jumps on first paint and on agent/plugin switches.
-fn render_loading(theme: &Theme, spinner_frame: usize) -> AnyElement {
+fn render_loading(theme: &Theme, lex: &Lexicon, spinner_frame: usize) -> AnyElement {
     let frame = SPINNER_FRAMES[spinner_frame % SPINNER_FRAMES.len()];
     div()
         .flex()
@@ -1239,19 +1251,20 @@ fn render_loading(theme: &Theme, spinner_frame: usize) -> AnyElement {
             div()
                 .text_xs()
                 .text_color(rgb(theme.colors.text_dim))
-                .child("Loading…"),
+                .child(lex.loading),
         )
         .into_any_element()
 }
 
 fn render_quota(
     theme: &Theme,
+    lex: &Lexicon,
     quota: Option<&QuotaSnapshot>,
     accent: u32,
     spinner_frame: usize,
 ) -> AnyElement {
     let Some(quota) = quota else {
-        return render_loading(theme, spinner_frame);
+        return render_loading(theme, lex, spinner_frame);
     };
 
     let mut col = div().flex().flex_col().px_4().py_3().gap_3();
@@ -1262,7 +1275,7 @@ fn render_quota(
             div()
                 .text_xs()
                 .text_color(rgb(theme.colors.text_dim))
-                .child(SharedString::from(format!("Subscription: {sub}"))),
+                .child(SharedString::from((lex.subscription_fmt)(sub))),
         );
     }
 
@@ -1282,12 +1295,12 @@ fn render_quota(
                     .bg(rgb(theme.colors.surface))
                     .text_color(rgb(theme.colors.text_dim))
                     .text_xs()
-                    .child("No quota data available."),
+                    .child(lex.no_quota_data),
             );
         }
     } else {
         for w in &quota.windows {
-            col = col.child(render_quota_window(theme, w, accent));
+            col = col.child(render_quota_window(theme, lex, w, accent));
         }
     }
 
@@ -1354,7 +1367,12 @@ fn render_fallback_warning(theme: &Theme, quota: &QuotaSnapshot) -> AnyElement {
         .into_any_element()
 }
 
-fn render_quota_window(theme: &Theme, w: &QuotaWindow, accent: u32) -> impl IntoElement {
+fn render_quota_window(
+    theme: &Theme,
+    lex: &Lexicon,
+    w: &QuotaWindow,
+    accent: u32,
+) -> impl IntoElement {
     let pct_label = match w.used_percentage {
         Some(p) => format!("{:.0}% used", p),
         None => match w.used_tokens {
@@ -1426,7 +1444,7 @@ fn render_quota_window(theme: &Theme, w: &QuotaWindow, accent: u32) -> impl Into
             div()
                 .text_xs()
                 .text_color(rgb(theme.colors.text_dim))
-                .child(SharedString::from(format!("Resets {}", label))),
+                .child(SharedString::from((lex.resets_fmt)(&label))),
         );
     }
 
@@ -1474,12 +1492,13 @@ fn format_reset(ts: DateTime<Utc>) -> String {
 
 fn render_forecast(
     theme: &Theme,
+    lex: &Lexicon,
     forecast: Option<&ForecastSnapshot>,
     accent: u32,
     spinner_frame: usize,
 ) -> AnyElement {
     let Some(forecast) = forecast else {
-        return render_loading(theme, spinner_frame);
+        return render_loading(theme, lex, spinner_frame);
     };
 
     let mut col = div().flex().flex_col().px_4().py_3().gap_3();
@@ -1501,19 +1520,24 @@ fn render_forecast(
         );
     } else {
         for w in &forecast.windows {
-            col = col.child(render_forecast_window(theme, w, accent));
+            col = col.child(render_forecast_window(theme, lex, w, accent));
         }
     }
 
     col.into_any_element()
 }
 
-fn render_forecast_window(theme: &Theme, w: &ForecastWindow, accent: u32) -> impl IntoElement {
+fn render_forecast_window(
+    theme: &Theme,
+    lex: &Lexicon,
+    w: &ForecastWindow,
+    accent: u32,
+) -> impl IntoElement {
     let (badge_text, badge_color) = match w.status {
-        ForecastStatus::Ok => ("On track", accent),
-        ForecastStatus::Watch => ("Watch", theme.colors.warning),
-        ForecastStatus::Overshoot => ("Overshoot", theme.colors.error),
-        ForecastStatus::Insufficient => ("—", theme.colors.text_dim),
+        ForecastStatus::Ok => (lex.forecast_ok, accent),
+        ForecastStatus::Watch => (lex.forecast_watch, theme.colors.warning),
+        ForecastStatus::Overshoot => (lex.forecast_overshoot, theme.colors.error),
+        ForecastStatus::Insufficient => (lex.forecast_insufficient, theme.colors.text_dim),
     };
 
     let header = div()
@@ -1555,7 +1579,7 @@ fn render_forecast_window(theme: &Theme, w: &ForecastWindow, accent: u32) -> imp
             div()
                 .text_xs()
                 .text_color(rgb(theme.colors.text_dim))
-                .child("warming up — check back in a few minutes"),
+                .child(lex.forecast_warming_up),
         );
         return card;
     }
@@ -1625,11 +1649,11 @@ fn render_forecast_window(theme: &Theme, w: &ForecastWindow, accent: u32) -> imp
     let subtext = match w.status {
         ForecastStatus::Overshoot => w
             .overshoot_at
-            .map(|t| format!("Will hit 100% at {}", format_reset(t)))
+            .map(|t| (lex.forecast_will_hit_100_fmt)(&format_reset(t)))
             .unwrap_or_else(|| "Projected to overshoot".to_string()),
         _ => match w.resets_at {
-            Some(t) => format!("Projected at reset {}", format_reset(t)),
-            None => "Projected at reset".to_string(),
+            Some(t) => format!("{} {}", lex.forecast_projected_at_reset, format_reset(t)),
+            None => lex.forecast_projected_at_reset.to_string(),
         },
     };
     card = card.child(
@@ -2145,6 +2169,7 @@ impl AuraView {
         let text = self.theme.colors.text;
         let text_dim = self.theme.colors.text_dim;
         let surface_hi = self.theme.colors.surface_hi;
+        let lex = lexicon::pick(self.config.display.goblin_mode);
 
         // ── Open config file ─────────────────────────────────────────────────
         card = card.child(
@@ -2161,7 +2186,7 @@ impl AuraView {
                 .text_color(rgb(text))
                 .hover(move |d| d.bg(rgb(surface_hi)))
                 .child(svg_icon("icons/arrow_up_right.svg", text_dim, 14.0))
-                .child("Open config file")
+                .child(lex.menu_open_config)
                 .on_click(cx.listener(|view, _: &ClickEvent, _, cx| {
                     view.open_config(cx);
                     view.close_settings_panel(cx);
@@ -2183,7 +2208,7 @@ impl AuraView {
                 .text_color(rgb(text))
                 .hover(move |d| d.bg(rgb(surface_hi)))
                 .child(svg_icon("icons/sliders.svg", text_dim, 14.0))
-                .child("Themes")
+                .child(lex.menu_themes)
                 .on_click(cx.listener(|view, _: &ClickEvent, _, cx| {
                     view.open_theme(cx);
                     view.close_settings_panel(cx);


### PR DESCRIPTION
- **docs(roadmap): plan Forecast tab; drop redundant cost-alerts entry**
- **docs(roadmap): plan Goblin Mode easter-egg lexicon**
- **feat(forecast): add Forecast tab projecting end-of-window usage**
- **feat(ui): add Goblin Mode lexicon for swappable UI copy**
