### PR TITLE
feature/dismissable update button

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,11 +498,13 @@ dependencies = [
  "objc",
  "raw-window-handle",
  "resvg 0.47.0",
+ "semver",
  "serde",
  "serde_json",
  "tiny-skia 0.12.0",
  "toml 1.1.2+spec-1.1.0",
  "tray-icon",
+ "ureq",
  "windows 0.61.3",
 ]
 
@@ -5100,6 +5102,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ clap                  = { version = "4", features = ["derive", "wrap_help"] }
 clap_complete         = "4"
 dirs                  = "6"
 notify-debouncer-mini = "0.7"
+semver                = { version = "1", features = ["serde"] }
 serde                 = { version = "1", features = ["derive"] }
 serde_json            = "1"
 thiserror             = "2"

--- a/README.md
+++ b/README.md
@@ -470,23 +470,57 @@ which install path you took.
 
 ### Updating
 
-Re-running `./install.sh` always writes the new binary, but the **running
-process** is only replaced automatically on macOS (`launchctl kickstart -k`)
-and Windows (`Stop-Process` before copy). On Linux the installer calls
-`systemctl --user enable --now aura`, which is a no-op when the unit is
-already running — so the tray keeps serving the old build until you restart
-it explicitly.
+When Aura notices a newer GitHub release on startup it shows an
+**Update available · vX.Y.Z** chip in the modal header. Clicking it
+opens this section. The simple, dependency-free path is **two curls /
+two `iex`s** — no `cargo`, no `just`, no checkout required:
 
 ```bash
-# Linux — after ./install.sh, swap the old binary in:
-systemctl --user restart aura
-
-# macOS / Windows — nothing extra; ./install.sh (or scripts/install.ps1)
-# already restarted the process for you.
+# Linux / macOS
+curl -fsSL https://raw.githubusercontent.com/Rfluid/aura/main/uninstall.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Rfluid/aura/main/install.sh   | bash
 ```
 
-If you opted out of the systemd autostart (or `systemctl --user restart aura`
-reports "no such unit"), kill the stray tray process directly:
+```powershell
+# Windows (PowerShell)
+iex (irm https://raw.githubusercontent.com/Rfluid/aura/main/scripts/uninstall.ps1)
+iex (irm https://raw.githubusercontent.com/Rfluid/aura/main/scripts/install.ps1)
+```
+
+The uninstall script stops the running tray, removes the binary +
+autostart artifacts, and clears the KDE keepalive rule (see
+[Uninstall](#uninstall) for the full list). The install script then
+fetches the latest GitHub release archive, verifies its checksum, and
+puts the new binary back in place — autostart and all. **Your config
+and state are preserved** through both halves.
+
+The GitHub fetch behind the header chip sends a `User-Agent:
+aura/<version>` header (required by GitHub's API) and your source IP.
+No cookies, no auth, no body. To mute the chip without uninstalling,
+set `[update] dismiss_all = true` in `~/.config/aura/config.toml` —
+that skips the network call entirely.
+
+#### From a cloned checkout
+
+If you have the repo cloned and built from source, `just update` (or
+`just update-windows`) does the equivalent locally — it calls `just
+uninstall` then `just install`, which in turn shell out to the same
+`uninstall.sh` / `install.sh` scripts above.
+
+#### Updating only the running binary (advanced)
+
+The installer always restarts the tray on macOS (`launchctl kickstart
+-k`) and Windows (`Stop-Process` before copy). On Linux it calls
+`systemctl --user enable --now aura`, which is a no-op when the unit
+is already running — so if you skipped the two-curl flow and just
+swapped binaries you'll need to bounce the unit:
+
+```bash
+# Linux — after dropping a new binary in ~/.local/bin/aura:
+systemctl --user restart aura
+```
+
+Or, when you opted out of the systemd autostart entirely:
 
 ```bash
 pkill -x aura && ~/.local/bin/aura >/dev/null 2>&1 &
@@ -607,6 +641,7 @@ Shipped
 - [x] macOS support (Apple Silicon + Intel; menu-bar `Aura.app` + launchd autostart)
 - [x] Windows support (x86_64 + aarch64; Shell_NotifyIcon tray + Startup-folder autostart)
 - [x] Per-DE polish: auto-installed KWin rule on KDE to hide the keepalive surface
+- [x] **Update button** — header chip that surfaces a newer GitHub release on startup and links to the two-curl update flow. Design: [`docs/plans/update-button.md`](docs/plans/update-button.md)
 
 Next up
 

--- a/crates/aura-core/src/config.rs
+++ b/crates/aura-core/src/config.rs
@@ -160,6 +160,24 @@ impl Default for DisplayConfig {
     }
 }
 
+// ── Update ───────────────────────────────────────────────────────────────────
+
+/// Controls the "Update available" header button. The button is gated on a
+/// background fetch of the latest GitHub release; both knobs here let the
+/// user mute that surface without disabling the rest of the app.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct UpdateConfig {
+    /// The last release version the user dismissed via the "x" on the
+    /// update button. Stored as the bare semver string ("0.1.18"). Any
+    /// newer release re-shows the button. `None` means "never dismissed".
+    pub dismissed_version: Option<String>,
+    /// Master switch. When true, the update button is never rendered and
+    /// the background check is skipped entirely (so no GitHub request
+    /// fires). Off by default.
+    pub dismiss_all: bool,
+}
+
 // ── AppConfig ─────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -170,6 +188,8 @@ pub struct AppConfig {
     pub plugins: Vec<PluginConfig>,
     #[serde(default)]
     pub display: DisplayConfig,
+    #[serde(default)]
+    pub update: UpdateConfig,
 }
 
 impl AppConfig {
@@ -219,6 +239,7 @@ impl AppConfig {
             agents: known_agent_profiles(),
             plugins: Vec::new(),
             display: DisplayConfig::default(),
+            update: UpdateConfig::default(),
         }
     }
 
@@ -463,6 +484,7 @@ mod tests {
                 plugin_order: vec!["Gamma".into(), "Alpha".into()],
                 ..DisplayConfig::default()
             },
+            update: UpdateConfig::default(),
         };
         cfg.apply_plugin_order();
         let names: Vec<&str> = cfg.plugins.iter().map(|p| p.name.as_str()).collect();
@@ -479,6 +501,7 @@ mod tests {
                 plugin_order: vec!["hello".into(), "Nonexistent".into()],
                 ..DisplayConfig::default()
             },
+            update: UpdateConfig::default(),
         };
         cfg.apply_plugin_order();
         let names: Vec<&str> = cfg.plugins.iter().map(|p| p.name.as_str()).collect();
@@ -491,6 +514,7 @@ mod tests {
             agents: vec![],
             plugins: vec![plug("Alpha"), plug("Beta")],
             display: DisplayConfig::default(),
+            update: UpdateConfig::default(),
         };
         cfg.apply_plugin_order();
         let names: Vec<&str> = cfg.plugins.iter().map(|p| p.name.as_str()).collect();
@@ -507,6 +531,30 @@ mod tests {
         assert_eq!(parsed.agents[0].name, cfg.agents[0].name);
         assert_eq!(parsed.plugins.len(), cfg.plugins.len());
         assert_eq!(parsed.display, cfg.display);
+        assert_eq!(parsed.update, cfg.update);
+    }
+
+    #[test]
+    fn update_config_defaults_when_block_missing() {
+        let cfg: AppConfig = toml::from_str("").unwrap();
+        assert_eq!(cfg.update, UpdateConfig::default());
+        assert!(cfg.update.dismissed_version.is_none());
+        assert!(!cfg.update.dismiss_all);
+    }
+
+    #[test]
+    fn update_config_round_trips_populated_block() {
+        let toml_in = r#"
+[update]
+dismissed_version = "0.1.18"
+dismiss_all = true
+"#;
+        let cfg: AppConfig = toml::from_str(toml_in).unwrap();
+        assert_eq!(cfg.update.dismissed_version.as_deref(), Some("0.1.18"));
+        assert!(cfg.update.dismiss_all);
+        let round = toml::to_string_pretty(&cfg).unwrap();
+        let again: AppConfig = toml::from_str(&round).unwrap();
+        assert_eq!(again.update, cfg.update);
     }
 
     #[test]
@@ -539,6 +587,7 @@ mod tests {
             }],
             plugins: vec![],
             display: DisplayConfig::default(),
+            update: UpdateConfig::default(),
         };
 
         let added = cfg.merge_agents(vec![
@@ -576,6 +625,7 @@ mod tests {
             }],
             plugins: vec![],
             display: DisplayConfig::default(),
+            update: UpdateConfig::default(),
         };
 
         let added = cfg.merge_agents(vec![AgentConfig {

--- a/crates/aura-core/src/lexicon.rs
+++ b/crates/aura-core/src/lexicon.rs
@@ -42,6 +42,15 @@ pub struct Lexicon {
     // ── More menu ───────────────────────────────────────────────────────────
     pub menu_open_config: &'static str,
     pub menu_themes: &'static str,
+    /// Modal-row label for "Check updates", with the running version
+    /// appended (e.g. "Check updates · v0.1.17"). Goblin gets to roast
+    /// the user's current build.
+    pub check_updates_fmt: fn(current_version: &str) -> String,
+
+    // ── Update button ───────────────────────────────────────────────────────
+    /// Header chip label when a newer release exists. The arrow at the
+    /// end is part of the persona — keep or replace as you see fit.
+    pub update_available_fmt: fn(latest_version: &str) -> String,
 
     // ── Period pills ────────────────────────────────────────────────────────
     pub period_all: &'static str,
@@ -58,6 +67,12 @@ fn polite_resets(when: &str) -> String {
 fn polite_will_hit_100(time: &str) -> String {
     format!("Will hit 100% at {time}")
 }
+fn polite_check_updates(current: &str) -> String {
+    format!("Check updates · v{current}")
+}
+fn polite_update_available(latest: &str) -> String {
+    format!("Update available · v{latest} →")
+}
 
 fn goblin_subscription(sub: &str) -> String {
     format!("Paying for: {sub}")
@@ -67,6 +82,12 @@ fn goblin_resets(when: &str) -> String {
 }
 fn goblin_will_hit_100(time: &str) -> String {
     format!("Goose is cooked at {time}")
+}
+fn goblin_check_updates(current: &str) -> String {
+    format!("Running ancient · v{current}")
+}
+fn goblin_update_available(latest: &str) -> String {
+    format!("New build dropped · v{latest} →")
 }
 
 /// Default voice. Verbatim copy of what the modal renders today — flipping
@@ -96,6 +117,9 @@ pub const POLITE: Lexicon = Lexicon {
 
     menu_open_config: "Open config file",
     menu_themes: "Themes",
+    check_updates_fmt: polite_check_updates,
+
+    update_available_fmt: polite_update_available,
 
     period_all: "All time",
     period_7d: "Last 7 days",
@@ -129,6 +153,9 @@ pub const GOBLIN: Lexicon = Lexicon {
 
     menu_open_config: "Crack open the config",
     menu_themes: "Paint job",
+    check_updates_fmt: goblin_check_updates,
+
+    update_available_fmt: goblin_update_available,
 
     period_all: "the whole damn time",
     period_7d: "last week",
@@ -265,6 +292,14 @@ mod tests {
             (POLITE.forecast_will_hit_100_fmt)("5pm"),
             "Will hit 100% at 5pm",
         );
+        assert_eq!(
+            (POLITE.check_updates_fmt)("0.1.17"),
+            "Check updates · v0.1.17",
+        );
+        assert_eq!(
+            (POLITE.update_available_fmt)("0.1.18"),
+            "Update available · v0.1.18 →",
+        );
     }
 
     #[test]
@@ -274,6 +309,14 @@ mod tests {
         assert_eq!(
             (GOBLIN.forecast_will_hit_100_fmt)("5pm"),
             "Goose is cooked at 5pm",
+        );
+        assert_eq!(
+            (GOBLIN.check_updates_fmt)("0.1.17"),
+            "Running ancient · v0.1.17",
+        );
+        assert_eq!(
+            (GOBLIN.update_available_fmt)("0.1.18"),
+            "New build dropped · v0.1.18 →",
         );
     }
 }

--- a/crates/aura/Cargo.toml
+++ b/crates/aura/Cargo.toml
@@ -19,8 +19,10 @@ dirs.workspace          = true
 gpui                    = { version = "0.2", features = ["runtime_shaders"] }
 raw-window-handle       = "0.6"
 resvg                   = { version = "0.47", default-features = false }
+semver.workspace        = true
 serde.workspace         = true
 serde_json.workspace    = true
+ureq.workspace          = true
 tiny-skia               = "0.12"
 toml.workspace          = true
 

--- a/crates/aura/src/app.rs
+++ b/crates/aura/src/app.rs
@@ -895,11 +895,12 @@ impl AuraView {
         let Some(info) = &self.update else {
             return div().into_any_element();
         };
+        let lex = lexicon::pick(self.config.display.goblin_mode);
         let accent = self.theme.colors.accent;
         let text = self.theme.colors.text;
         let text_dim = self.theme.colors.text_dim;
         let surface_hi = self.theme.colors.surface_hi;
-        let label = format!("Update available · v{} →", info.latest);
+        let label = (lex.update_available_fmt)(&info.latest.to_string());
 
         let label_btn = div()
             .id("update-open")
@@ -2183,9 +2184,10 @@ fn progress_bar(theme: &Theme, fraction: f64, accent: u32, height: f32) -> impl 
 
 impl AuraView {
     fn render_more_modal(&self, cx: &mut Context<Self>) -> AnyElement {
+        let lex = lexicon::pick(self.config.display.goblin_mode);
         // Append the running version so users can confirm the build they're
         // on without trawling stderr or `aura --version`.
-        let updates_label = format!("Check updates · v{}", env!("CARGO_PKG_VERSION"));
+        let updates_label = (lex.check_updates_fmt)(env!("CARGO_PKG_VERSION"));
         let items: [(&'static str, &'static str, String, ModalAction); 4] = [
             (
                 "modal-updates",

--- a/crates/aura/src/app.rs
+++ b/crates/aura/src/app.rs
@@ -19,6 +19,7 @@ use gpui::{
 };
 
 use crate::format::{duration, hour_of_day, locale_uses_12h, system_locale, thousands};
+use crate::updater::{self, UpdateInfo};
 
 /// Fixed window width. The window grows vertically to fit content (see
 /// `on_children_prepainted` in `render`), so only the height is dynamic.
@@ -101,6 +102,14 @@ pub struct AuraView {
     /// Indexed by plugin name.
     plugin_panels: Vec<(String, PluginPanel)>,
 
+    /// Latest GitHub release info, populated by a background fetch at
+    /// startup. `None` means the check hasn't completed yet, failed, or the
+    /// remote version is not newer than the local build. Stays set after
+    /// success — dismissing only writes the version into config; the field
+    /// itself isn't cleared so re-opening the modal in the same session
+    /// honours the dismissal without a flicker.
+    update: Option<UpdateInfo>,
+
     show_more_modal: bool,
     show_settings_panel: bool,
     is_loading: bool,
@@ -182,6 +191,7 @@ impl AuraView {
             quota: None,
             forecast: None,
             plugin_panels: Vec::new(),
+            update: None,
             show_more_modal: false,
             show_settings_panel: false,
             is_loading: false,
@@ -194,7 +204,37 @@ impl AuraView {
         // Initial load: kick off the async refresh now so the spinner can
         // render on first paint instead of blocking construction.
         view.refresh(cx);
+        // Fire-and-forget release check. Skipped when the user disabled
+        // update prompts via `[update] dismiss_all = true` — that's the
+        // kill switch documented on `UpdateConfig::dismiss_all`.
+        if !view.config.update.dismiss_all {
+            view.spawn_update_check(cx);
+        }
         view
+    }
+
+    /// Spawn the GitHub release check on the background executor and push
+    /// the result back onto `AuraView.update` via `cx.notify()`. Errors are
+    /// logged to stderr and otherwise ignored — a failed check leaves the
+    /// header unchanged (see plan: degraded experience > noisy banner).
+    fn spawn_update_check(&self, cx: &mut Context<Self>) {
+        cx.spawn(async move |this, cx| {
+            let result = cx
+                .background_executor()
+                .spawn(async move { updater::fetch_latest() })
+                .await;
+            match result {
+                Ok(Some(info)) => {
+                    let _ = this.update(cx, |view, cx| {
+                        view.update = Some(info);
+                        cx.notify();
+                    });
+                }
+                Ok(None) => { /* already up-to-date */ }
+                Err(e) => eprintln!("aura: update check failed: {e}"),
+            }
+        })
+        .detach();
     }
 
     /// Kick off an async refresh. Returns immediately — the heavy work
@@ -502,6 +542,35 @@ impl AuraView {
         }
     }
 
+    /// Whether the "Update available" header chip should render. Pure
+    /// wrapper around [`should_show_update_button`] so the gating logic is
+    /// unit-testable without spinning up a full `AuraView`.
+    fn show_update_button(&self) -> bool {
+        should_show_update_button(self.update.as_ref(), &self.config.update)
+    }
+
+    /// Open the README's `### Updating` anchor — the two-curl / two-iex
+    /// flow lives there. We do not auto-download; see the plan's
+    /// "Non-goals" for why.
+    fn open_update_instructions(&mut self, _cx: &mut Context<Self>) {
+        open_url(updater::UPDATE_INSTRUCTIONS_URL);
+    }
+
+    /// Persist the dismissal so the button stays hidden across relaunches
+    /// for *this* version. A newer release than `info.latest` re-shows the
+    /// button automatically because `show_update_button` compares strings.
+    fn dismiss_update(&mut self, cx: &mut Context<Self>) {
+        let Some(info) = &self.update else {
+            return;
+        };
+        let version = info.latest.to_string();
+        self.config.update.dismissed_version = Some(version);
+        if let Err(e) = self.config.save(&self.config_path) {
+            self.error = Some(format!("Could not save dismissal: {e}"));
+        }
+        cx.notify();
+    }
+
     fn toggle_more_modal(&mut self, cx: &mut Context<Self>) {
         self.show_more_modal = !self.show_more_modal;
         cx.notify();
@@ -786,12 +855,12 @@ impl AuraView {
                 )
             });
 
-        // Right: action buttons (refresh, config, more)
-        let actions = div()
-            .flex()
-            .flex_row()
-            .items_center()
-            .gap_3()
+        // Right: optional update chip, then action buttons (refresh, config, more).
+        let mut actions = div().flex().flex_row().items_center().gap_3();
+        if self.show_update_button() {
+            actions = actions.child(self.render_update_button(cx));
+        }
+        actions = actions
             .child(
                 icon_button("act-refresh", "icons/rotate_cw.svg", &self.theme).on_click(
                     cx.listener(|view, _: &ClickEvent, _, cx| {
@@ -816,6 +885,59 @@ impl AuraView {
             );
 
         row.child(brand).child(actions).into_any_element()
+    }
+
+    /// The "Update available · vX.Y.Z" chip rendered in the header. Two
+    /// click targets: the label opens the README's updating section; the
+    /// trailing "×" persists a per-version dismissal so the chip vanishes
+    /// until the next release.
+    fn render_update_button(&self, cx: &mut Context<Self>) -> AnyElement {
+        let Some(info) = &self.update else {
+            return div().into_any_element();
+        };
+        let accent = self.theme.colors.accent;
+        let text = self.theme.colors.text;
+        let text_dim = self.theme.colors.text_dim;
+        let surface_hi = self.theme.colors.surface_hi;
+        let label = format!("Update available · v{} →", info.latest);
+
+        let label_btn = div()
+            .id("update-open")
+            .flex()
+            .flex_row()
+            .items_center()
+            .px_2()
+            .py_0p5()
+            .rounded_md()
+            .text_xs()
+            .text_color(rgb(text))
+            .bg(rgb(Theme::blend(accent, self.theme.colors.bg, 0.75)))
+            .hover(move |d| d.bg(rgb(surface_hi)))
+            .child(SharedString::from(label))
+            .on_click(cx.listener(|view, _: &ClickEvent, _, cx| view.open_update_instructions(cx)));
+
+        let dismiss_btn = div()
+            .id("update-dismiss")
+            .flex()
+            .items_center()
+            .justify_center()
+            .w(px(18.0))
+            .h(px(18.0))
+            .ml_1()
+            .rounded_md()
+            .text_xs()
+            .text_color(rgb(text_dim))
+            .hover(move |d| d.bg(rgb(surface_hi)).text_color(rgb(text)))
+            .child("×")
+            .on_click(cx.listener(|view, _: &ClickEvent, _, cx| view.dismiss_update(cx)));
+
+        div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .child(label_btn)
+            .child(dismiss_btn)
+            .into_any_element()
     }
 
     /// Pill row + agent/plugin mode toggle.
@@ -2061,29 +2183,32 @@ fn progress_bar(theme: &Theme, fraction: f64, accent: u32, height: f32) -> impl 
 
 impl AuraView {
     fn render_more_modal(&self, cx: &mut Context<Self>) -> AnyElement {
-        let items = [
+        // Append the running version so users can confirm the build they're
+        // on without trawling stderr or `aura --version`.
+        let updates_label = format!("Check updates · v{}", env!("CARGO_PKG_VERSION"));
+        let items: [(&'static str, &'static str, String, ModalAction); 4] = [
             (
                 "modal-updates",
                 "icons/download.svg",
-                "Check updates",
+                updates_label,
                 ModalAction::Updates,
             ),
             (
                 "modal-sponsor",
                 "icons/sparkle.svg",
-                "Sponsor",
+                "Sponsor".to_string(),
                 ModalAction::Sponsor,
             ),
             (
                 "modal-github",
                 "icons/github.svg",
-                "View on GitHub",
+                "View on GitHub".to_string(),
                 ModalAction::Github,
             ),
             (
                 "modal-issues",
                 "icons/circle_help.svg",
-                "Report issue",
+                "Report issue".to_string(),
                 ModalAction::Reports,
             ),
         ];
@@ -2131,7 +2256,7 @@ impl AuraView {
                     .text_color(rgb(self.theme.colors.text))
                     .hover(move |d| d.bg(rgb(surface_hi)))
                     .child(svg_icon(icon_path, self.theme.colors.text_dim, 14.0))
-                    .child(label)
+                    .child(SharedString::from(label))
                     .on_click(cx.listener(move |view, _: &ClickEvent, _, cx| {
                         view.handle_modal_action(action, cx);
                     })),
@@ -2321,3 +2446,71 @@ fn rgba(value: u32) -> gpui::Rgba {
 
 // `work_area` lives at `crate::work_area`; both this module and `main.rs`
 // use it. See `work_area.rs` for the parsing rationale.
+
+/// Pure form of `AuraView::show_update_button`. Returns true when there
+/// is fetched update info, the user hasn't muted all update prompts, and
+/// they haven't already dismissed *this exact* version.
+fn should_show_update_button(
+    update: Option<&UpdateInfo>,
+    cfg: &aura_core::config::UpdateConfig,
+) -> bool {
+    let Some(info) = update else {
+        return false;
+    };
+    if cfg.dismiss_all {
+        return false;
+    }
+    !matches!(&cfg.dismissed_version, Some(v) if *v == info.latest.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aura_core::config::UpdateConfig;
+    use semver::Version;
+
+    fn info(v: &str) -> UpdateInfo {
+        UpdateInfo {
+            latest: Version::parse(v).unwrap(),
+        }
+    }
+
+    #[test]
+    fn hides_when_no_update_info() {
+        let cfg = UpdateConfig::default();
+        assert!(!should_show_update_button(None, &cfg));
+    }
+
+    #[test]
+    fn hides_when_dismiss_all_set() {
+        let cfg = UpdateConfig {
+            dismissed_version: None,
+            dismiss_all: true,
+        };
+        assert!(!should_show_update_button(Some(&info("0.1.18")), &cfg));
+    }
+
+    #[test]
+    fn hides_when_dismissed_version_matches_latest() {
+        let cfg = UpdateConfig {
+            dismissed_version: Some("0.1.18".into()),
+            dismiss_all: false,
+        };
+        assert!(!should_show_update_button(Some(&info("0.1.18")), &cfg));
+    }
+
+    #[test]
+    fn shows_when_dismissed_older_release_and_newer_is_out() {
+        let cfg = UpdateConfig {
+            dismissed_version: Some("0.1.18".into()),
+            dismiss_all: false,
+        };
+        assert!(should_show_update_button(Some(&info("0.1.19")), &cfg));
+    }
+
+    #[test]
+    fn shows_when_never_dismissed() {
+        let cfg = UpdateConfig::default();
+        assert!(should_show_update_button(Some(&info("0.1.18")), &cfg));
+    }
+}

--- a/crates/aura/src/main.rs
+++ b/crates/aura/src/main.rs
@@ -9,6 +9,7 @@ mod format;
 mod platform;
 mod runtime;
 mod tray;
+mod updater;
 mod work_area;
 
 #[cfg(target_os = "macos")]

--- a/crates/aura/src/updater.rs
+++ b/crates/aura/src/updater.rs
@@ -1,0 +1,154 @@
+//! Background "is a newer release available?" check.
+//!
+//! Aura ships from GitHub releases. There is no in-app downloader (see
+//! `docs/plans/update-button.md` for the rationale): we just compare the
+//! local `CARGO_PKG_VERSION` against `releases/latest` from the GitHub
+//! REST API and, when a newer tag is out, surface a header button that
+//! opens the README's `### Updating` anchor.
+//!
+//! The fetch is synchronous and lives in a single function so the caller
+//! can spawn it on GPUI's background executor without dragging in
+//! tokio. Errors are non-UI — a degraded check (timeout, 5xx, malformed
+//! body) yields `Err` and the caller drops the button silently.
+
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use semver::Version;
+use serde::Deserialize;
+
+/// GitHub's anonymous release endpoint. Returns the metadata for the most
+/// recent non-draft release. Anonymous requests are rate-limited to 60/hr
+/// per IP; a once-per-launch fetch is comfortably below that.
+const RELEASES_API_URL: &str = "https://api.github.com/repos/Rfluid/aura/releases/latest";
+
+/// What the user clicks on the update button: the README's `### Updating`
+/// anchor on `main`. GitHub's slug rules turn `### Updating` into
+/// `#updating`, which is stable as long as the heading text doesn't
+/// change.
+pub const UPDATE_INSTRUCTIONS_URL: &str =
+    "https://github.com/Rfluid/aura/blob/main/README.md#updating";
+
+/// Outcome of a successful release check.
+#[derive(Debug, Clone)]
+pub struct UpdateInfo {
+    /// The remote tag with the leading 'v' stripped — e.g. "0.1.18".
+    pub latest: Version,
+}
+
+/// `env!("CARGO_PKG_VERSION")` parsed into a `semver::Version`. Panics at
+/// compile-time-determined-string-parse only if Aura's own version
+/// somehow fails to parse, which would be a build-script bug.
+pub fn current_version() -> Version {
+    Version::parse(env!("CARGO_PKG_VERSION")).expect("aura version is valid semver")
+}
+
+/// Synchronous network call. Spawned on the background executor by
+/// `AuraView::new`; never called from the render thread.
+///
+/// Returns `Ok(Some(info))` when a newer release exists, `Ok(None)` when
+/// the local build is up-to-date or newer, and `Err(_)` on any failure
+/// (timeout, non-200 status, missing field, unparseable semver).
+pub fn fetch_latest() -> Result<Option<UpdateInfo>> {
+    // 5s end-to-end. GitHub usually answers in well under a second, but a
+    // captive-portal hijack can dribble bytes forever otherwise.
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_global(Some(Duration::from_secs(5)))
+        .build()
+        .into();
+
+    // GitHub requires a User-Agent on every API request.
+    let ua = format!("aura/{}", env!("CARGO_PKG_VERSION"));
+    let mut response = agent
+        .get(RELEASES_API_URL)
+        .header("User-Agent", ua.as_str())
+        .header("Accept", "application/vnd.github+json")
+        .call()
+        .map_err(|e| anyhow!("GitHub releases call failed: {e}"))?;
+
+    if response.status() != 200 {
+        return Err(anyhow!(
+            "GitHub releases returned HTTP {}",
+            response.status()
+        ));
+    }
+
+    let body = response
+        .body_mut()
+        .read_to_string()
+        .context("reading releases response body")?;
+
+    let info = parse_release_response(&body)?;
+    let current = current_version();
+    if info.latest > current {
+        Ok(Some(info))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Stripped-down view of the GitHub `releases/latest` payload — only the
+/// `tag_name` field. Everything else (release notes, asset URLs, draft
+/// flags) is irrelevant here; the button just opens the README anchor.
+#[derive(Debug, Deserialize)]
+struct ReleaseEnvelope {
+    tag_name: String,
+}
+
+/// Parse a GitHub `releases/latest` JSON body into an `UpdateInfo`. Split
+/// out so the unit tests can cover the parsing without making a network
+/// call.
+pub fn parse_release_response(body: &str) -> Result<UpdateInfo> {
+    let envelope: ReleaseEnvelope = serde_json::from_str(body).context("parsing releases JSON")?;
+    let trimmed = envelope.tag_name.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("releases response had empty tag_name"));
+    }
+    // Tags ship as `v0.1.18`; `Version::parse` rejects the leading 'v'.
+    let stripped = trimmed.strip_prefix('v').unwrap_or(trimmed);
+    let latest =
+        Version::parse(stripped).with_context(|| format!("parsing release tag `{trimmed}`"))?;
+    Ok(UpdateInfo { latest })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_release_response_strips_leading_v() {
+        let body = r#"{"tag_name": "v0.1.99"}"#;
+        let info = parse_release_response(body).unwrap();
+        assert_eq!(info.latest, Version::parse("0.1.99").unwrap());
+    }
+
+    #[test]
+    fn parse_release_response_accepts_bare_semver() {
+        let body = r#"{"tag_name": "1.2.3"}"#;
+        let info = parse_release_response(body).unwrap();
+        assert_eq!(info.latest, Version::parse("1.2.3").unwrap());
+    }
+
+    #[test]
+    fn parse_release_response_rejects_missing_tag_name() {
+        let body = r#"{"name": "v0.1.18"}"#;
+        let err = parse_release_response(body).unwrap_err();
+        assert!(err.to_string().contains("parsing releases JSON"));
+    }
+
+    #[test]
+    fn parse_release_response_rejects_bad_semver() {
+        let body = r#"{"tag_name": "v-not-a-version"}"#;
+        let err = parse_release_response(body).unwrap_err();
+        assert!(
+            err.to_string().contains("parsing release tag"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn current_version_parses() {
+        // Just ensure the env value round-trips through semver at runtime.
+        let _ = current_version();
+    }
+}

--- a/docs/plans/forecast-tab.md
+++ b/docs/plans/forecast-tab.md
@@ -5,10 +5,10 @@ version: 0.1.0
 last_updated: 2026-05-27
 last_verified: 2026-05-27
 source_refs:
-  - crates/aura-core/src/quota/mod.rs
-  - crates/aura-core/src/quota/api.rs
-  - crates/aura-core/src/reader/mod.rs
-  - crates/aura/src/app.rs
+    - crates/aura-core/src/quota/mod.rs
+    - crates/aura-core/src/quota/api.rs
+    - crates/aura-core/src/reader/mod.rs
+    - crates/aura/src/app.rs
 owner: "@rfluid"
 tags: [forecast, quota, roadmap, design]
 ---
@@ -217,10 +217,10 @@ can add a 60s tick later.
 - Wire up `Forecast` tab and `render_forecast()`.
 - Hook into `RefreshResult` / `do_refresh()`.
 - Tests in `crates/aura-core/src/quota/forecast.rs`:
-  - linear extrapolation at 25%, 50%, 75% elapsed
-  - `Insufficient` when elapsed < 5%
-  - `Overshoot` + `overshoot_at` correctness
-  - empty `QuotaSnapshot` → empty `ForecastSnapshot` (no panic)
+    - linear extrapolation at 25%, 50%, 75% elapsed
+    - `Insufficient` when elapsed < 5%
+    - `Overshoot` + `overshoot_at` correctness
+    - empty `QuotaSnapshot` → empty `ForecastSnapshot` (no panic)
 
 ### Phase 2 — Codex
 

--- a/docs/plans/goblin-mode.md
+++ b/docs/plans/goblin-mode.md
@@ -5,10 +5,10 @@ version: 0.1.0
 last_updated: 2026-05-27
 last_verified: 2026-05-27
 source_refs:
-  - crates/aura-core/src/config.rs
-  - crates/aura/src/app.rs
-  - crates/aura/src/format.rs
-  - docs/forecast-tab.md
+    - crates/aura-core/src/config.rs
+    - crates/aura/src/app.rs
+    - crates/aura/src/format.rs
+    - docs/forecast-tab.md
 owner: "@rfluid"
 tags: [easter-egg, ui, lexicon, design]
 ---
@@ -48,13 +48,13 @@ In scope:
   (`Ok` / `Watch` / `Overshoot` / `Insufficient`), `Subscription:`,
   `Resets <when>`, period pills (`all` / `7d` / `30d`).
 - **Empty / loading / error states**: `Loading…`, `No quota data
-  available.`, `No plugins configured`, `No plugin selected`,
+available.`, `No plugins configured`, `No plugin selected`,
   `warming up — check back in a few minutes` (forecast),
   generic error banner copy.
 - **More-menu entries**: `Open config file`, `Themes`, future
   Settings/Refresh labels.
 - **Forecast-tab subtext**: `Projected at reset`, `Will hit 100%
-  at HH:MM`.
+at HH:MM`.
 
 Out of scope for v1:
 
@@ -192,31 +192,31 @@ Voice rules for `GOBLIN`:
 Working drafts (final pass during impl; treat these as direction, not
 spec):
 
-| Field | Polite | Goblin |
-|---|---|---|
-| `tab_quota` | Quota | Damage |
-| `tab_summary` | Summary | The Bill |
-| `tab_models` | Models | Slop Vendors |
-| `tab_plugins` | Plugins | Hangers-on |
-| `tab_forecast` | Forecast | Doom |
-| `forecast_ok` | OK | Fine, whatever |
-| `forecast_watch` | Watch | Bruh |
-| `forecast_overshoot` | Overshoot | Cooked |
-| `forecast_insufficient` | Insufficient | Idk yet |
-| `forecast_projected_at_reset` | Projected at reset | What you'll burn |
-| `forecast_will_hit_100_fmt(t)` | Will hit 100% at {t} | Goose is cooked at {t} |
-| `forecast_warming_up` | warming up — check back in a few minutes | give it a minute, jeez |
-| `loading` | Loading… | hold on damn |
-| `no_quota_data` | No quota data available. | Nothing. Empty. Dry. |
-| `no_plugins_configured` | No plugins configured | No hangers-on |
-| `no_plugin_selected` | No plugin selected | Pick one, coward |
-| `subscription_fmt(s)` | Subscription: {s} | Paying for: {s} |
-| `resets_fmt(w)` | Resets {w} | Wipes {w} |
-| `menu_open_config` | Open config file | Crack open the config |
-| `menu_themes` | Themes | Paint job |
-| `period_all` | all | the whole damn time |
-| `period_7d` | 7d | last week |
-| `period_30d` | 30d | this month-ish |
+| Field                          | Polite                                   | Goblin                 |
+| ------------------------------ | ---------------------------------------- | ---------------------- |
+| `tab_quota`                    | Quota                                    | Damage                 |
+| `tab_summary`                  | Summary                                  | The Bill               |
+| `tab_models`                   | Models                                   | Slop Vendors           |
+| `tab_plugins`                  | Plugins                                  | Hangers-on             |
+| `tab_forecast`                 | Forecast                                 | Doom                   |
+| `forecast_ok`                  | OK                                       | Fine, whatever         |
+| `forecast_watch`               | Watch                                    | Bruh                   |
+| `forecast_overshoot`           | Overshoot                                | Cooked                 |
+| `forecast_insufficient`        | Insufficient                             | Idk yet                |
+| `forecast_projected_at_reset`  | Projected at reset                       | What you'll burn       |
+| `forecast_will_hit_100_fmt(t)` | Will hit 100% at {t}                     | Goose is cooked at {t} |
+| `forecast_warming_up`          | warming up — check back in a few minutes | give it a minute, jeez |
+| `loading`                      | Loading…                                 | hold on damn           |
+| `no_quota_data`                | No quota data available.                 | Nothing. Empty. Dry.   |
+| `no_plugins_configured`        | No plugins configured                    | No hangers-on          |
+| `no_plugin_selected`           | No plugin selected                       | Pick one, coward       |
+| `subscription_fmt(s)`          | Subscription: {s}                        | Paying for: {s}        |
+| `resets_fmt(w)`                | Resets {w}                               | Wipes {w}              |
+| `menu_open_config`             | Open config file                         | Crack open the config  |
+| `menu_themes`                  | Themes                                   | Paint job              |
+| `period_all`                   | all                                      | the whole damn time    |
+| `period_7d`                    | 7d                                       | last week              |
+| `period_30d`                   | 30d                                      | this month-ish         |
 
 Period pills are tight on width; if `the whole damn time` overflows
 in practice, fall back to `forever` / `week` / `month` — verify in

--- a/docs/plans/update-button.md
+++ b/docs/plans/update-button.md
@@ -1,0 +1,535 @@
+---
+title: Update button
+status: design
+version: 0.1.0
+last_updated: 2026-05-27
+last_verified: 2026-05-27
+source_refs:
+    - crates/aura/src/app.rs
+    - crates/aura/src/platform.rs
+    - crates/aura/src/runtime.rs
+    - crates/aura-core/src/config.rs
+    - crates/aura-core/Cargo.toml
+    - crates/aura/Cargo.toml
+    - install.sh
+    - justfile
+    - scripts/install.ps1
+    - README.md
+owner: "@rfluid"
+tags: [updates, ui, releases, header, design]
+---
+
+# Update button
+
+## Problem
+
+Aura ships from GitHub releases (Linux/macOS tarballs, Windows zip) and
+the installer scripts at `install.sh` / `scripts/install.ps1`. There is
+no in-app signal that a newer version exists: users either re-run the
+installer on a hunch or notice the version drift accidentally on the
+GitHub releases page. The **More** modal already has a "Check updates"
+row, but it just opens `…/aura/releases` in a browser — it doesn't tell
+the user whether an update is _actually_ available and it doesn't tell
+them which version they're on right now.
+
+Reference: Zed's `crates/title_bar/src/update_version.rs` +
+`crates/ui/src/components/collab/update_button.rs` render a small
+title-bar button when an update is available and provide a dismiss
+"x". We want the same _UX_ — a visible nudge — without the auto-
+downloader. Aura's update path stays "open the install script in a
+shell"; the button just _surfaces the offer_.
+
+## Scope
+
+1. **Background release check on app open** — fetch the latest GitHub
+   release tag, compare against `env!("CARGO_PKG_VERSION")`, surface
+   the result. Must be non-blocking: if GitHub is slow / offline /
+   rate-limiting us, the modal still opens at normal speed and nothing
+   else stalls.
+2. **Header update button** — visible only when a newer release exists,
+   not dismissed, and the user hasn't disabled all update prompts. Two
+   parts: a clickable label ("Update available · v0.1.18 →") and an "x"
+   dismiss affordance.
+3. **More modal "Check updates" gets a version label** — the row already
+   exists; append the current Aura version (e.g. "Check updates ·
+   v0.1.17") so a user inspecting the modal can confirm the build they
+   are on.
+4. **Dismissal model** — store the last dismissed version in
+   `config.toml`. Re-show the button when a newer version is released
+   (i.e. dismissing v0.1.18 does not suppress v0.1.19). Add a
+   _"never show update prompts"_ toggle for users who don't want
+   nudges at all.
+5. **Click-through download flow** — clicking the update label opens
+   the browser at the README's updating section. The README documents
+   a **two-curl flow** ("uninstall script" piped to bash, then "install
+   script" piped to bash) that works on Linux/macOS without `cargo` /
+   `just` / any other dev tooling. Windows gets the equivalent two-iex
+   block. This means extracting the existing `justfile` `uninstall:` /
+   `uninstall-windows:` logic into standalone scripts (`uninstall.sh`,
+   `scripts/uninstall.ps1`) that the README can point at.
+
+## Non-goals
+
+- **Auto-download / auto-install.** Aura is a tray indicator; the
+  binary it ships is replaced from outside the running process. The
+  button only opens the README; the user runs the curl pipes. Zed's
+  in-app downloader is explicitly out of scope.
+- **Pre-release / nightly channels.** Aura has one channel (the latest
+  stable GitHub release). No `release_channel` enum needed.
+- **Notifying users who already updated.** Zed posts a "Updated to
+  X.Y.Z" toast on first launch after an update; we skip that. The
+  README is enough.
+- **Telemetry on click / dismiss.** Aura has none today and this
+  feature does not introduce any.
+- **Update check on a recurring timer while Aura runs.** Aura's tray
+  app stays alive across many modal opens, but a check on **app
+  startup** is sufficient — users have to re-open the modal to see
+  the button anyway, and re-checking every modal open is wasteful.
+  Future work: refetch when the modal opens if the last check is older
+  than 24h. Tracked under [Future work](#future-work).
+
+## Design
+
+### Pipeline overview
+
+```text
+Aura process starts
+        │
+        ├─ AuraView::new() builds config + state from disk
+        │
+        ├─ Spawn background fetch (smol task on the background executor):
+        │     GET https://api.github.com/repos/Rfluid/aura/releases/latest
+        │     Accept: application/vnd.github+json
+        │     User-Agent: aura/<version>            ← GH requires UA
+        │     timeout = 5s
+        │
+        ├─ On success: parse `tag_name`, strip leading 'v', compare
+        │     against env!("CARGO_PKG_VERSION") via semver::Version.
+        │     If latest > current → write the latest tag into a shared
+        │     atomic / `Arc<Mutex<Option<UpdateState>>>` consumed by
+        │     the view.
+        │
+        ├─ On failure (timeout, network, 4xx/5xx, malformed JSON):
+        │     log to stderr and keep `UpdateState = None`. Never bubble
+        │     to the UI — a failed check is invisible by design.
+        │
+        └─ View next renders. Header button visibility derived from:
+              UpdateState.is_some()
+                && state.latest_tag != config.update.dismissed_version
+                && !config.update.dismiss_all
+```
+
+Everything off the foreground executor uses the existing
+`cx.background_executor().spawn(...)` pattern (see `app.rs` line 222 in
+`do_refresh`). The fetch task takes a weak handle to the view and
+updates a field via `this.update(cx, |view, cx| { … cx.notify(); })`
+the same way `do_refresh` does.
+
+### Why a background _executor_ task, not a `std::thread::spawn`
+
+`platform::open_url` uses `std::thread::Builder::spawn` because it is
+fire-and-forget — there is no UI state to push back. The update check
+**does** push state back, so it needs the GPUI weak-handle pattern so
+the result lands on the foreground executor at notify time. Mirrors
+`do_refresh` exactly.
+
+### Why GitHub's `releases/latest` JSON endpoint, not the HTML page
+
+`api.github.com/repos/Rfluid/aura/releases/latest` returns 32 KB of
+JSON with `tag_name` at the top level — easy to parse with
+`serde_json` (already a workspace dep). The HTML page is ~150 KB
+and would need regex / scraping. Anonymous GitHub API calls are rate-
+limited to 60/hour per IP; once-per-app-start is well within that.
+
+If we want to skip parsing entirely, the **redirect endpoint**
+`https://github.com/Rfluid/aura/releases/latest` returns a 302 whose
+`Location` header points at `.../releases/tag/vX.Y.Z` and we could
+sniff the tag out of the URL. Cheaper but quirkier; defer unless the
+JSON endpoint becomes problematic.
+
+### Data shape
+
+New module: `crates/aura/src/updater.rs`.
+
+```rust
+pub struct UpdateInfo {
+    /// The remote tag, with the leading 'v' stripped — e.g. "0.1.18".
+    pub latest: semver::Version,
+    /// What the user clicks. The release page is fine as a fallback
+    /// destination, but we prefer the README anchor (see below).
+    pub release_url: String,
+}
+
+pub fn current_version() -> semver::Version {
+    semver::Version::parse(env!("CARGO_PKG_VERSION")).expect("aura version is valid semver")
+}
+
+/// Synchronous network call. Spawned on the background executor; never
+/// called from the render thread.
+pub fn fetch_latest() -> anyhow::Result<UpdateInfo>;
+```
+
+`UpdateInfo` is stored on `AuraView` as
+`update: Option<UpdateInfo>`. It is set once on app start by the
+background task and never cleared at runtime (a successful dismissal
+only writes the version into config — the field stays set so re-
+opening the modal in the same session honours the click without a
+flicker).
+
+### Config additions
+
+New table in `crates/aura-core/src/config.rs`:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct UpdateConfig {
+    /// The last release version the user dismissed via the "x" on the
+    /// update button. Stored as the bare semver string ("0.1.18"). Any
+    /// newer release re-shows the button. `None` means "never
+    /// dismissed".
+    pub dismissed_version: Option<String>,
+    /// Master switch. When true, the update button is never rendered
+    /// and the background check is skipped entirely (saves the GH
+    /// request). Off by default.
+    pub dismiss_all: bool,
+}
+
+impl Default for UpdateConfig {
+    fn default() -> Self {
+        Self { dismissed_version: None, dismiss_all: false }
+    }
+}
+
+// In AppConfig:
+#[serde(default)]
+pub update: UpdateConfig,
+```
+
+Lives at the top level (not nested under `display`) because the dismiss
+state is functional, not display preference, and because Zed's settings
+do the same — auto-update lives in its own settings module.
+
+On-disk shape (added to the default `config.toml`):
+
+```toml
+[update]
+dismissed_version = "0.1.18"   # optional
+dismiss_all       = false
+```
+
+### Why store in `config.toml` (not `state.json`)
+
+`state.json` is for transient app-managed runtime state (`AppState` only
+tracks `active_profile` today). `dismissed_version` is conceptually
+similar — it is _state_, not user preference. But the user-facing
+control _"dismiss all updates"_ is a true preference, and keeping the
+two halves split across two files would surprise users who think they
+disabled the prompts in config and then see `dismissed_version` drift
+in `state.json`. Putting both in `config.toml` also matches the
+intended behaviour: the user can hand-edit either field to mute / re-
+enable the button without firing the UI.
+
+### Header button placement
+
+`render_header` in `crates/aura/src/app.rs:760` currently builds an
+`actions` flex-row with three icon buttons: refresh, settings, more.
+
+```text
+┌── header ────────────────────────────────────────────────────┐
+│ [logo] [⠋]                          [↻] [⚙] [⋯]              │   today
+│ [logo] [⠋]    [Update · v0.1.18 →][x]  [↻] [⚙] [⋯]            │   with button
+└──────────────────────────────────────────────────────────────┘
+```
+
+Place the new element **left of the icon group**, inside the same
+flex-row, behind a `when(self.show_update_button(), ...)` guard so the
+layout collapses cleanly when there is no update.
+
+The component itself is bespoke (Zed's `UpdateButton` lives in
+`gpui-zed-ui` and is intertwined with their `ButtonLike` /
+`AnnouncementToast` stack — we are not adopting any of that). It is
+~30 lines: a rounded bordered container with a label + a small "x"
+child. Tooltip on the label reads "Open update instructions"; tooltip
+on "x" reads "Hide until next release". Both wired through
+`cx.listener` to view methods (`open_update_instructions`,
+`dismiss_update`).
+
+The button only paints when:
+
+```rust
+fn show_update_button(&self) -> bool {
+    let Some(info) = &self.update else { return false; };
+    if self.config.update.dismiss_all { return false; }
+    match &self.config.update.dismissed_version {
+        Some(v) if *v == info.latest.to_string() => false,
+        _ => true,
+    }
+}
+```
+
+`dismiss_update` writes the latest version into
+`self.config.update.dismissed_version`, calls `AppConfig::save(...)`,
+and `cx.notify()`. Saving on dismiss matches how the rest of the modal
+treats config writes (`open_config` opens the file; user edits;
+re-load on next refresh) — but here the in-memory copy must update
+immediately so the button hides on the same paint, so we mutate before
+we write.
+
+### More modal version label
+
+Today the "Check updates" row in `render_more_modal`
+(`app.rs:2063`) is a static label `"Check updates"`. Replace with:
+
+```rust
+let current = env!("CARGO_PKG_VERSION");
+let label = format!("Check updates · v{}", current);
+```
+
+No state change; just a derived string. Clicking the row keeps its
+existing behaviour (`open_url(GITHUB_RELEASES_URL)`) so the modal-side
+flow stays "browse all releases", while the **header button** routes
+to "do an update now" (the README anchor — see below).
+
+### Download / update click-through
+
+Clicking the header update button opens the browser at:
+
+```
+https://github.com/Rfluid/aura/blob/main/README.md#updating
+```
+
+The README's `### Updating` section (line 471 today) will be rewritten
+to document the **two-curl flow** — the simple path the user asked for:
+
+```bash
+# Linux / macOS
+curl -fsSL https://raw.githubusercontent.com/Rfluid/aura/main/uninstall.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Rfluid/aura/main/install.sh   | bash
+```
+
+```powershell
+# Windows (PowerShell)
+iex (irm https://raw.githubusercontent.com/Rfluid/aura/main/scripts/uninstall.ps1)
+iex (irm https://raw.githubusercontent.com/Rfluid/aura/main/scripts/install.ps1)
+```
+
+This requires extracting two scripts out of the `justfile` so the
+README can curl them:
+
+- `uninstall.sh` (new, repo root) — mirrors the Linux + macOS arms of
+  the `justfile uninstall:` recipe (lines 81–128). Detects OS, tears
+  down systemd / launchd autostart, kills the process, removes the
+  binary, removes the `.desktop` / `Aura.app`. macOS Git Bash falls
+  through with the same redirect message `install.sh` uses today.
+- `scripts/uninstall.ps1` (new) — mirrors the `justfile
+uninstall-windows:` recipe (lines 132–140): stops `aura.exe`, removes
+  Start Menu + Startup shortcuts, removes
+  `%LOCALAPPDATA%\Programs\Aura`.
+
+The `justfile` recipes become thin wrappers that just invoke the new
+scripts so contributors keep one source of truth:
+
+```make
+uninstall:
+    ./uninstall.sh
+
+uninstall-windows:
+    powershell -ExecutionPolicy Bypass -File scripts/uninstall.ps1
+```
+
+`install.sh` and `scripts/install.ps1` already work from
+`curl | bash` / `iex (irm …)` — see `install.sh:5` "run via `curl |
+bash`: downloads the latest GitHub release archive". The uninstall
+scripts only need the same shebang + `set -euo pipefail` discipline,
+no resolved `ROOT` directory (they operate purely on `~/.local/...` /
+`%LOCALAPPDATA%`).
+
+### Why the README anchor, not a dedicated `aura update` URL
+
+We considered shipping a `aura update` CLI subcommand that runs the
+uninstall+install pipe. Two reasons we don't:
+
+1. **Trust** — piping `curl | bash` is something a user opts into
+   knowingly. Hiding it behind an in-app button surprises users when
+   `sudo` prompts (Windows) or password prompts (KWin keepalive rule)
+   pop up.
+2. **Re-entrancy** — the install scripts kill the running `aura`
+   process. If `aura` is the one orchestrating that, we get a half-
+   updated system. The button opens a browser; the user opens a
+   terminal; the running tray dies cleanly when the install script
+   does the `pkill -x aura`.
+
+So the button is exactly a "here are the instructions" hand-off. The
+README anchor reads as a checklist; the user pastes the two lines into
+a terminal and is done.
+
+### Cross-platform open
+
+`crate::platform::open_url(url)` already handles all three platforms
+(see `platform.rs:282–324`): `open` on macOS, `ShellExecute` on
+Windows, `xdg-open` elsewhere. No new platform code is needed for the
+click-through. The existing `ModalAction::Updates` handler already
+exercises this path.
+
+### Required plumbing
+
+| Crate       | Item                                                                                          |
+| ----------- | --------------------------------------------------------------------------------------------- |
+| `aura-core` | `UpdateConfig` struct + `AppConfig.update` field + default round-trip test (`config.rs:501`). |
+| `aura-core` | `semver` workspace dep (currently absent — used by the comparison in `aura`).                 |
+| `aura`      | New `crates/aura/src/updater.rs` exposing `fetch_latest()` and `current_version()`.           |
+| `aura`      | `AuraView.update: Option<UpdateInfo>` + spawn in `AuraView::new` or just after `do_refresh`.  |
+| `aura`      | `render_header` adds the button left of the icon group (`app.rs:790`).                        |
+| `aura`      | `render_more_modal` "Check updates" gains the `· vX.Y.Z` suffix (`app.rs:2068`).              |
+| `aura`      | View methods `open_update_instructions` and `dismiss_update`; latter writes config to disk.   |
+| Repo root   | New `uninstall.sh` (Linux + macOS arms of the existing justfile recipe).                      |
+| `scripts/`  | New `scripts/uninstall.ps1` (Windows arm of the existing justfile recipe).                    |
+| `justfile`  | `uninstall:` and `uninstall-windows:` recipes become thin wrappers around the new scripts.    |
+| `README.md` | `### Updating` section rewritten to show the two-curl / two-iex flow.                         |
+
+### Constants
+
+Add to `app.rs` next to `GITHUB_REPO_URL` / `GITHUB_RELEASES_URL`:
+
+```rust
+const UPDATE_INSTRUCTIONS_URL: &str =
+    "https://github.com/Rfluid/aura/blob/main/README.md#updating";
+const GITHUB_RELEASES_API_URL: &str =
+    "https://api.github.com/repos/Rfluid/aura/releases/latest";
+```
+
+Both are stable: the README anchor follows GitHub's slug rules
+(`#updating` matches `### Updating`); the API URL is GitHub's public
+contract.
+
+### Error handling
+
+The fetch task uses `ureq::get(GITHUB_RELEASES_API_URL).timeout(5s)`
+and `serde_json` to decode `{ "tag_name": "v0.1.18" }`. Every error
+path (timeout, non-200 status, missing field, unparseable semver) is
+logged at `eprintln!` parity with `open_url_blocking` and silently
+yields `None`. **There is no UI surface for "update check failed"** —
+a degraded experience that hides the button is strictly preferable to
+a noisy "couldn't check" banner.
+
+Rate-limit headers (`X-RateLimit-Remaining`) are inspected only for the
+log line. We don't gate the next call on them — the once-per-launch
+cadence is well below the 60/hr anonymous quota and the user can run
+Aura indefinitely without hitting it.
+
+### Tests
+
+- `config.rs` — extend `default_config_round_trips_through_toml`
+  (line 501) to assert `UpdateConfig::default` deserialises from an
+  empty `[update]` block, and that a populated block round-trips.
+- `updater.rs` — unit test for a stubbed `parse_release_response`
+  helper that takes a `&str` (JSON body) and returns
+  `anyhow::Result<UpdateInfo>`. Covers happy path, missing
+  `tag_name`, leading-`v` handling, and bad semver. Network is **not**
+  mocked — `fetch_latest()` itself is left untested at the unit level
+  (manual smoke on first run).
+- `app.rs` — `show_update_button()` is pure: add a test that walks
+  the four states (`dismiss_all=true`, `dismissed_version` matches,
+  `dismissed_version` older, `update=None`) and asserts the bool.
+  This is the highest-value test in the feature — it gates _all_ UI
+  behaviour.
+
+### Telemetry / privacy
+
+The GitHub fetch sends:
+
+- User-Agent: `aura/<version>` (required by GH; identifies the tool,
+  not the user).
+- Source IP (unavoidable, anonymous).
+- No cookies, no auth headers, no body.
+
+This matches what running `curl https://api.github.com/...` from a
+terminal would send. Documented in the README updating section.
+
+The `dismiss_all` toggle is the user-facing kill switch for the
+network call. When `dismiss_all=true`, `fetch_latest()` is **not
+called at all** — the background task short-circuits at spawn time.
+
+## Implementation steps
+
+Ordered so the repo stays compileable between steps.
+
+1. **Add `semver` to `[workspace.dependencies]`** in the root
+   `Cargo.toml` (or just to `aura/Cargo.toml`; root keeps it
+   reusable). Add it to `aura/Cargo.toml`'s `[dependencies]`.
+2. **`aura-core`: add `UpdateConfig`** + `AppConfig.update` with
+   `#[serde(default)]`. Extend the round-trip test. Bump
+   `aura-core` patch.
+3. **`aura`: add `updater.rs`** exporting `current_version()`,
+   `fetch_latest()`, `UpdateInfo`, and `parse_release_response`
+   (the tested helper).
+4. **`aura`: wire the fetch into `AuraView`.** Field
+   `update: Option<UpdateInfo>`. Background-executor spawn on `new()`;
+   on success, `this.update(cx, |view, cx| { view.update = Some(info);
+cx.notify(); })`. Skip the spawn when `config.update.dismiss_all`.
+5. **`aura`: header button.** Render conditionally; wire
+   `open_update_instructions(cx)` and `dismiss_update(cx)` methods.
+6. **`aura`: more-modal version label.** One-line change in
+   `render_more_modal`.
+7. **Repo: `uninstall.sh`.** Copy the Linux + macOS branches out of
+   `justfile`; keep KWin-rule cleanup intact. Make executable.
+8. **Repo: `scripts/uninstall.ps1`.** Copy the Windows branch out of
+   `justfile`. PowerShell quoting is finicky — use a `param()`-less
+   script so `iex (irm …)` works.
+9. **`justfile`: recipes become wrappers.** Two-line bodies.
+10. **`README.md`: rewrite `### Updating`.** Two-curl + two-iex blocks
+    above the existing systemd-restart / kickstart notes. The notes
+    stay (they apply when users build from source).
+11. **Manual smoke (per platform).** Confirm: (a) the button appears
+    when Aura's `Cargo.toml` version is artificially decremented and
+    the binary launched, (b) clicking opens the README anchor in the
+    default browser, (c) "x" dismisses and persists across a relaunch,
+    (d) editing `dismiss_all = true` in `config.toml` and relaunching
+    skips the network call (verify via stderr log line) and never
+    renders the button.
+
+## Rollout
+
+Single PR — all pieces are interdependent. The button can be feature-
+flagged off via `config.update.dismiss_all = true` if it misbehaves in
+the wild, so a separate gate is unnecessary.
+
+Add a `## Update button` entry to the `Roadmap` under `## v0.2 — Codex
+
+- polish`(or`## v0.3 — Plugin ecosystem`, depending on where the
+  0.2 cutline lands at merge time).
+
+## Future work
+
+- **Refetch on modal open** when the last successful check is older
+  than 24h. Requires a `Instant` field on the in-memory state; no
+  config impact. Cheap follow-up.
+- **Update button copy variant for Goblin Mode.** Trivial once the
+  feature lands — add fields like `lex.update_available` /
+  `lex.dismiss_update` to `Lexicon`. Today the strings live inline in
+  `app.rs`.
+- **Tray-icon overlay badge** when an update is available, so users
+  who never open the modal still see the nudge. Needs a per-platform
+  tray-icon redraw path and is more invasive than the button.
+- **`aura update` CLI** — opt-in subcommand that runs the two-curl
+  flow non-interactively. Held off because of the re-entrancy risk
+  noted above; would need a "spawn detached, then exec the script"
+  trampoline.
+- **Recurring fetch on a daily timer** while Aura is running, so
+  long-lived tray sessions (Aura is the kind of app a user leaves up
+  for weeks) eventually surface releases without a relaunch.
+
+## References
+
+- Zed's title-bar update button:
+  `~/development/zed/crates/title_bar/src/update_version.rs` and
+  `~/development/zed/crates/ui/src/components/collab/update_button.rs`.
+  We borrow the state-machine + dismiss-x affordance; we do **not**
+  adopt Zed's auto-downloader (`crates/auto_update/src/auto_update.rs`).
+- GitHub releases API:
+  `https://docs.github.com/en/rest/releases/releases#get-the-latest-release`.
+- Existing cross-platform browser open:
+  `crates/aura/src/platform.rs:282`.
+- Existing config / state split:
+  `crates/aura-core/src/config.rs`, `crates/aura-core/src/state.rs`.

--- a/justfile
+++ b/justfile
@@ -78,66 +78,19 @@ update-windows: uninstall-windows install-windows
 
 # ── Uninstall ─────────────────────────────────────────────────────────────────
 
+# Linux + macOS uninstall — disables autostart, kills the running tray,
+# removes binaries / launchers / units, clears the KDE keepalive rule.
+# The actual logic lives in uninstall.sh so the README's "two-curl
+# update" instructions can fetch it directly without a checkout.
 uninstall:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    case "$(uname -s)" in
-        Linux)
-            # Disable autostart, stop the running tray, then clear the
-            # binaries + launcher + systemd unit.
-            systemctl --user disable --now aura 2>/dev/null || true
-            pkill -x aura 2>/dev/null || true
-            rm -f ~/.local/bin/aura
-            rm -f ~/.local/share/applications/aura.desktop
-            rm -f ~/.local/share/icons/hicolor/scalable/apps/aura.svg
-            rm -f ~/.config/systemd/user/aura.service
-            command -v update-desktop-database >/dev/null 2>&1 && \
-                update-desktop-database ~/.local/share/applications >/dev/null 2>&1 || true
-            command -v gtk-update-icon-cache >/dev/null 2>&1 && \
-                gtk-update-icon-cache -f -t ~/.local/share/icons/hicolor >/dev/null 2>&1 || true
-            # KDE-only: remove the keepalive skip-taskbar rule installed by
-            # install.sh, then ask KWin to reload its rules.
-            if command -v kwriteconfig6 >/dev/null 2>&1 && command -v kreadconfig6 >/dev/null 2>&1; then
-                rule_id="aura-keepalive-skip-taskbar"
-                current=$(kreadconfig6 --file kwinrulesrc --group General --key rules 2>/dev/null || true)
-                new=$(echo "$current" | tr ',' '\n' | grep -vFx "$rule_id" | paste -sd ',' -)
-                kwriteconfig6 --file kwinrulesrc --group General --key rules "$new"
-                kwriteconfig6 --file kwinrulesrc --group General --key count \
-                    "$(echo "$new" | tr ',' '\n' | grep -c . || echo 0)"
-                kwriteconfig6 --file kwinrulesrc --group "$rule_id" --key Description --delete 2>/dev/null || true
-                command -v qdbus6 >/dev/null 2>&1 && qdbus6 org.kde.KWin /KWin reconfigure >/dev/null 2>&1 || true
-            fi
-            ;;
-        Darwin)
-            # Unload the LaunchAgent (stops the menu-bar tray) then remove
-            # the agent plist + Aura.app + bare binaries.
-            launchctl bootout "gui/$(id -u)/com.aura.agent-usage" 2>/dev/null || true
-            rm -f ~/Library/LaunchAgents/com.aura.agent-usage.plist
-            rm -rf /Applications/Aura.app ~/Applications/Aura.app
-            rm -f ~/.local/bin/aura
-            ;;
-        MINGW*|MSYS*|CYGWIN*)
-            echo "Run 'just uninstall-windows' from PowerShell on Windows." >&2
-            exit 1
-            ;;
-        *)
-            echo "warning: unknown OS, removing binaries only" >&2
-            rm -f ~/.local/bin/aura
-            ;;
-    esac
-    echo "✔ Removed binaries and launcher (config + state preserved)"
+    ./uninstall.sh
 
 # Windows-only uninstall: removes binaries + Start Menu shortcut. Also
-# cleans up the legacy Startup-folder shortcut from older installs.
+# cleans up the legacy Startup-folder shortcut from older installs. The
+# script lives in scripts/uninstall.ps1 so the README's `iex (irm ...)`
+# update instructions can fetch it directly.
 uninstall-windows:
-    powershell -ExecutionPolicy Bypass -Command "$ErrorActionPreference='Stop'; \
-        $dir = Join-Path $env:LOCALAPPDATA 'Programs\\Aura'; \
-        $startMenu = Join-Path ([Environment]::GetFolderPath('StartMenu')) 'Programs\\Aura.lnk'; \
-        $startup   = Join-Path ([Environment]::GetFolderPath('Startup')) 'Aura.lnk'; \
-        Get-Process aura -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue; \
-        foreach ($p in @($startMenu, $startup)) { if (Test-Path $p) { Remove-Item $p } }; \
-        if (Test-Path $dir) { Remove-Item -Recurse -Force $dir }; \
-        Write-Host '✔ Removed binaries and Start Menu shortcut (config + state preserved)'"
+    powershell -ExecutionPolicy Bypass -File scripts/uninstall.ps1
 
 # ── Process control (convenience wrappers) ────────────────────────────────────
 #

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -1,0 +1,48 @@
+<#
+.SYNOPSIS
+    Uninstall Aura on Windows.
+
+.DESCRIPTION
+    Mirror of the `just uninstall-windows` recipe extracted as a
+    standalone script so the README can run it via
+    `iex (irm https://raw.githubusercontent.com/Rfluid/aura/main/scripts/uninstall.ps1)`
+    without requiring a cloned checkout or `just`.
+
+    Stops aura.exe, removes the Start Menu shortcut (legacy
+    Startup-folder shortcut too if present), then removes the install
+    directory at %LOCALAPPDATA%\Programs\Aura. Config + state in
+    %APPDATA%\aura are preserved.
+
+.NOTES
+    Keep in sync with the `uninstall-windows:` recipe in justfile.
+    ASCII-only source: avoids PowerShell 5.1 UTF-8-without-BOM parse errors.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+# PowerShell 5.1 defaults to TLS 1.0/1.1 on older Windows; force 1.2 in
+# case anything below ever needs HTTPS (matches install.ps1).
+try {
+    [Net.ServicePointManager]::SecurityProtocol =
+        [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+} catch {}
+
+$InstallDir = Join-Path $env:LOCALAPPDATA 'Programs\Aura'
+$StartMenu  = Join-Path ([Environment]::GetFolderPath('StartMenu')) 'Programs\Aura.lnk'
+$Startup    = Join-Path ([Environment]::GetFolderPath('Startup')) 'Aura.lnk'
+
+# Stop the running tray so the binary isn't locked when we delete it.
+Get-Process aura -ErrorAction SilentlyContinue |
+    Stop-Process -Force -ErrorAction SilentlyContinue
+
+foreach ($p in @($StartMenu, $Startup)) {
+    if (Test-Path $p) {
+        Remove-Item $p
+    }
+}
+
+if (Test-Path $InstallDir) {
+    Remove-Item -Recurse -Force $InstallDir
+}
+
+Write-Host '✔ Removed binaries and Start Menu shortcut (config + state preserved)'

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Aura uninstall script — Linux + macOS.
+#
+# Mirrors the `just uninstall` recipe so the README can curl this file
+# directly (`curl -fsSL .../uninstall.sh | bash`) without requiring the
+# user to have `just` / `cargo` / a cloned checkout. The `just` recipe
+# itself is now a thin wrapper that invokes this script.
+#
+# Tears down:
+#
+#   Linux:  disables the systemd --user autostart, kills the running
+#           tray, removes ~/.local/bin/aura + .desktop + icon + unit,
+#           clears the KDE keepalive skip-taskbar rule, refreshes the
+#           desktop/icon caches.
+#   macOS:  unloads the launchd LaunchAgent, removes the plist, removes
+#           /Applications/Aura.app + ~/Applications/Aura.app + the bare
+#           binary in ~/.local/bin.
+#
+# Config (`~/.config/aura/config.toml`) and state
+# (`~/.local/share/aura/state.json`) are preserved by design — `just
+# update` calls this script before re-installing.
+
+set -euo pipefail
+
+case "$(uname -s)" in
+    Linux)
+        # Disable autostart, stop the running tray, then clear the
+        # binaries + launcher + systemd unit.
+        systemctl --user disable --now aura 2>/dev/null || true
+        pkill -x aura 2>/dev/null || true
+        rm -f ~/.local/bin/aura
+        rm -f ~/.local/share/applications/aura.desktop
+        rm -f ~/.local/share/icons/hicolor/scalable/apps/aura.svg
+        rm -f ~/.config/systemd/user/aura.service
+        command -v update-desktop-database >/dev/null 2>&1 && \
+            update-desktop-database ~/.local/share/applications >/dev/null 2>&1 || true
+        command -v gtk-update-icon-cache >/dev/null 2>&1 && \
+            gtk-update-icon-cache -f -t ~/.local/share/icons/hicolor >/dev/null 2>&1 || true
+        # KDE-only: remove the keepalive skip-taskbar rule installed by
+        # install.sh, then ask KWin to reload its rules.
+        if command -v kwriteconfig6 >/dev/null 2>&1 && command -v kreadconfig6 >/dev/null 2>&1; then
+            rule_id="aura-keepalive-skip-taskbar"
+            current=$(kreadconfig6 --file kwinrulesrc --group General --key rules 2>/dev/null || true)
+            new=$(echo "$current" | tr ',' '\n' | grep -vFx "$rule_id" | paste -sd ',' -)
+            kwriteconfig6 --file kwinrulesrc --group General --key rules "$new"
+            kwriteconfig6 --file kwinrulesrc --group General --key count \
+                "$(echo "$new" | tr ',' '\n' | grep -c . || echo 0)"
+            kwriteconfig6 --file kwinrulesrc --group "$rule_id" --key Description --delete 2>/dev/null || true
+            command -v qdbus6 >/dev/null 2>&1 && qdbus6 org.kde.KWin /KWin reconfigure >/dev/null 2>&1 || true
+        fi
+        ;;
+    Darwin)
+        # Unload the LaunchAgent (stops the menu-bar tray) then remove
+        # the agent plist + Aura.app + bare binaries.
+        launchctl bootout "gui/$(id -u)/com.aura.agent-usage" 2>/dev/null || true
+        rm -f ~/Library/LaunchAgents/com.aura.agent-usage.plist
+        rm -rf /Applications/Aura.app ~/Applications/Aura.app
+        rm -f ~/.local/bin/aura
+        ;;
+    MINGW*|MSYS*|CYGWIN*)
+        cat >&2 <<'EOF'
+error: this script is for Linux/macOS only.
+
+Run the PowerShell uninstaller instead (from PowerShell, not Git Bash):
+    iex (irm https://raw.githubusercontent.com/Rfluid/aura/main/scripts/uninstall.ps1)
+EOF
+        exit 1
+        ;;
+    *)
+        echo "warning: unknown OS, removing binaries only" >&2
+        rm -f ~/.local/bin/aura
+        ;;
+esac
+
+echo "✔ Removed binaries and launcher (config + state preserved)"


### PR DESCRIPTION
- **docs(roadmap): plan Forecast tab; drop redundant cost-alerts entry**
- **docs(roadmap): plan Goblin Mode easter-egg lexicon**
- **feat(forecast): add Forecast tab projecting end-of-window usage**
- **feat(ui): add Goblin Mode lexicon for swappable UI copy**
- **docs(refactor): implementation plans**
- **docs(plan): update button**
- **feat(ui): add dismissable update-available header button**
- **feat(ui): route update-button copy through Goblin Mode lexicon**
