### PR TITLE
fix/windows window drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,7 @@ dependencies = [
  "tray-icon",
  "ureq",
  "windows 0.61.3",
+ "x11rb",
 ]
 
 [[package]]

--- a/crates/aura-core/src/config.rs
+++ b/crates/aura-core/src/config.rs
@@ -88,7 +88,20 @@ pub struct PluginConfig {
 pub struct DisplayConfig {
     /// Which period to show by default: `"all"`, `"7d"`, or `"30d"`.
     pub default_period: String,
-    /// Modal anchor relative to the tray icon: `"auto"`, `"top"`, `"bottom"`.
+    /// How the modal anchors as it auto-fits its content height:
+    ///
+    /// - `"none"`   — open at the platform's natural tray corner and let the
+    ///   window grow downward from there; never reposition after a resize.
+    ///   Safe on Wayland, where the compositor owns window placement.
+    /// - `"bottom"` — pin the modal's bottom edge above a bottom taskbar so it
+    ///   grows *upward* (the tray-popup feel next to a bottom tray). Needs an
+    ///   active post-resize move (see `placement::Anchor`).
+    /// - `"top"`    — pin the top edge just below a top panel / menu bar and
+    ///   grow downward.
+    ///
+    /// The default is OS-specific (see [`default_anchor`]): `"bottom"` on
+    /// Windows (bottom taskbar), `"none"` on macOS and Linux. Unrecognised
+    /// values (including the legacy `"auto"`) fall back to the per-OS default.
     pub anchor: String,
     /// Display order for plugin pills. Plugins whose display `name`
     /// appears here render in the listed order; anything not named
@@ -145,11 +158,32 @@ pub struct DisplayConfig {
     pub goblin_mode: bool,
 }
 
+/// Per-OS default for [`DisplayConfig::anchor`]. Windows ships with a bottom
+/// taskbar, so the modal grows upward off the tray (`"bottom"`); macOS (menu
+/// bar at the top) and Linux (compositor owns placement) open at their natural
+/// corner without an active reposition (`"none"`).
+///
+/// Evaluated at compile time for the target this binary is built for, so the
+/// value baked into `default_config()` — and thus written to disk by the
+/// installer's `aura setup-config` and on first launch — is already correct
+/// for the platform. No install-time OS detection is needed in the shell
+/// scripts.
+fn default_anchor() -> String {
+    #[cfg(target_os = "windows")]
+    {
+        "bottom".to_string()
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        "none".to_string()
+    }
+}
+
 impl Default for DisplayConfig {
     fn default() -> Self {
         Self {
             default_period: "all".to_string(),
-            anchor: "auto".to_string(),
+            anchor: default_anchor(),
             plugin_order: Vec::new(),
             show_in_app_switcher: false,
             dismiss_on_focus_loss: true,
@@ -798,7 +832,8 @@ kind = "claude-code"
     fn display_config_defaults_on_missing_fields() {
         let cfg: AppConfig = toml::from_str("").unwrap();
         assert_eq!(cfg.display.default_period, "all");
-        assert_eq!(cfg.display.anchor, "auto");
+        // `anchor` defaults per-OS (see `default_anchor`).
+        assert_eq!(cfg.display.anchor, default_anchor());
     }
 
     #[test]

--- a/crates/aura/Cargo.toml
+++ b/crates/aura/Cargo.toml
@@ -43,6 +43,11 @@ toml.workspace          = true
 # point; `async-io` is the smol-style backend it uses under the hood
 # (lighter than the default `tokio` feature).
 ksni = { version = "0.3", default-features = false, features = ["blocking", "async-io"] }
+# Reposition the modal after the auto-fit resize on X11 (`anchor = "bottom"`).
+# GPUI exposes no move API, so we issue a ConfigureWindow ourselves against the
+# XCB window id (see platform::set_window_origin). Already in the tree via gpui.
+# No-op on Wayland, where the compositor owns surface placement.
+x11rb = "0.13"
 
 [target.'cfg(not(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd")))'.dependencies]
 tray-icon = { version = "0.24", default-features = false }

--- a/crates/aura/src/app.rs
+++ b/crates/aura/src/app.rs
@@ -660,6 +660,9 @@ impl Render for AuraView {
         // otherwise snap the height back every layout pass.
         let auto_fit = !self.config.display.window_chrome;
         let user_max_height = self.config.display.max_height;
+        // How the modal re-anchors after the auto-fit resize (see
+        // `placement::Anchor`). Only `Bottom` triggers an active move.
+        let anchor = crate::placement::Anchor::from_config(&self.config.display.anchor);
         #[cfg(target_os = "windows")]
         let needs_uncloak = self.needs_uncloak.clone();
         let mut root = div()
@@ -750,30 +753,36 @@ impl Render for AuraView {
                 let uncloak = needs_uncloak.clone();
                 window.on_next_frame(move |window, _cx| {
                     window.resize(new_size);
-                    // GPUI's resize() uses SWP_NOMOVE: it keeps the window's
-                    // top-left fixed and moves the bottom. A bottom-anchored
-                    // tray popup wants the opposite, so on Windows we move the
-                    // window back so its bottom hugs the taskbar (and lift the
-                    // open-time cloak). See platform::reposition_after_resize.
-                    #[cfg(target_os = "windows")]
-                    {
-                        // Desired top-left, computed *absolutely* from the work
-                        // area for the new content height — never read back from
-                        // the window's current position, which is what stops the
-                        // modal walking across the screen (issue #27).
-                        let desired = _cx.primary_display().map(|display| {
-                            let from_work = crate::placement::modal_origin(
+                    // GPUI's resize() keeps the window's top-left fixed and
+                    // moves the bottom. For a bottom-anchored modal we want the
+                    // opposite — the bottom edge should stay pinned to the
+                    // taskbar — so compute the desired top-left *absolutely*
+                    // from the work area (never read back from the live origin,
+                    // which is what made the window walk across the screen,
+                    // issue #27) and move there. `None`/`top` anchors don't
+                    // reposition: GPUI's grow-downward is already what they want.
+                    let desired = if anchor.needs_reposition() {
+                        _cx.primary_display().map(|display| {
+                            crate::placement::modal_origin(
                                 display.bounds(),
                                 None,
                                 f32::from(new_size.height),
-                            );
-                            // NOTE(#27): X is still taken from the live origin
-                            // here, which is the drift bug. The behavioural fix
-                            // is to use `from_work.x` instead — kept separate so
-                            // this refactor stays behaviour-preserving.
-                            gpui::point(window.bounds().origin.x, from_work.y)
-                        });
-                        crate::platform::reposition_after_resize(window, _cx, desired, &uncloak);
+                                anchor,
+                            )
+                        })
+                    } else {
+                        None
+                    };
+
+                    // On Windows the move also carries the open-time DWM
+                    // uncloak, which must fire after the resize regardless of
+                    // anchor (the window is cloaked on open in every anchor
+                    // mode). Elsewhere we just move when there's a target.
+                    #[cfg(target_os = "windows")]
+                    crate::platform::reposition_after_resize(window, _cx, desired, &uncloak);
+                    #[cfg(not(target_os = "windows"))]
+                    if let Some(origin) = desired {
+                        crate::platform::set_window_origin(window, _cx, origin);
                     }
                 });
             });

--- a/crates/aura/src/app.rs
+++ b/crates/aura/src/app.rs
@@ -749,18 +749,20 @@ impl Render for AuraView {
                 }
                 last_height.set(measured);
                 let new_size = size(px(WINDOW_WIDTH), measured);
+                // Captured for the direction-aware resize/move ordering below
+                // (only the non-Windows bottom-anchor path uses it).
+                #[cfg(not(target_os = "windows"))]
+                let prev_height = last;
                 #[cfg(target_os = "windows")]
                 let uncloak = needs_uncloak.clone();
                 window.on_next_frame(move |window, _cx| {
-                    window.resize(new_size);
-                    // GPUI's resize() keeps the window's top-left fixed and
-                    // moves the bottom. For a bottom-anchored modal we want the
-                    // opposite — the bottom edge should stay pinned to the
-                    // taskbar — so compute the desired top-left *absolutely*
-                    // from the work area (never read back from the live origin,
-                    // which is what made the window walk across the screen,
-                    // issue #27) and move there. `None`/`top` anchors don't
-                    // reposition: GPUI's grow-downward is already what they want.
+                    // For a bottom-anchored modal we want the *bottom* edge
+                    // pinned to the taskbar, so compute the desired top-left
+                    // *absolutely* from the work area (never read back from the
+                    // live origin, which is what made the window walk across the
+                    // screen, issue #27). `None`/`top` anchors don't reposition:
+                    // GPUI's grow-downward-from-a-fixed-top is already what they
+                    // want.
                     let desired = if anchor.needs_reposition() {
                         _cx.primary_display().map(|display| {
                             crate::placement::modal_origin(
@@ -774,15 +776,38 @@ impl Render for AuraView {
                         None
                     };
 
-                    // On Windows the move also carries the open-time DWM
-                    // uncloak, which must fire after the resize regardless of
-                    // anchor (the window is cloaked on open in every anchor
-                    // mode). Elsewhere we just move when there's a target.
+                    // On Windows GPUI's resize() keeps the top-left fixed; we
+                    // then move + lift the open-time DWM cloak, which must fire
+                    // after the resize regardless of anchor (the window is
+                    // cloaked on open in every anchor mode).
                     #[cfg(target_os = "windows")]
-                    crate::platform::reposition_after_resize(window, _cx, desired, &uncloak);
+                    {
+                        window.resize(new_size);
+                        crate::platform::reposition_after_resize(window, _cx, desired, &uncloak);
+                    }
+                    // Elsewhere, the resize and the bottom-anchor move are two
+                    // separate primitives (GPUI's resize() keeps the top fixed
+                    // and grows the bottom; an X11/EWMH move repositions the
+                    // top-left). We order them by direction so the window never
+                    // leaves the screen mid-transition — that off-screen
+                    // excursion is what looked like a slow, stretchy grow:
+                    //   • growing  → move the top *up* first, then grow the
+                    //                bottom down to meet the taskbar (never
+                    //                bulges past it).
+                    //   • shrinking → shrink the bottom up first (lifts off the
+                    //                taskbar), then slide down to re-pin.
+                    // `None`/`top` anchors just resize (grow downward).
                     #[cfg(not(target_os = "windows"))]
-                    if let Some(origin) = desired {
-                        crate::platform::set_window_origin(window, _cx, origin);
+                    match desired {
+                        Some(origin) if new_size.height > prev_height => {
+                            crate::platform::set_window_origin(window, _cx, origin);
+                            window.resize(new_size);
+                        }
+                        Some(origin) => {
+                            window.resize(new_size);
+                            crate::platform::set_window_origin(window, _cx, origin);
+                        }
+                        None => window.resize(new_size),
                     }
                 });
             });

--- a/crates/aura/src/app.rs
+++ b/crates/aura/src/app.rs
@@ -23,7 +23,9 @@ use crate::updater::{self, UpdateInfo};
 
 /// Fixed window width. The window grows vertically to fit content (see
 /// `on_children_prepainted` in `render`), so only the height is dynamic.
-const WINDOW_WIDTH: f32 = 520.0;
+/// Aliased to the single source of truth in `placement` so the open-time
+/// bounds and the auto-fit resize can never disagree on width.
+const WINDOW_WIDTH: f32 = crate::placement::MODAL_W;
 
 /// Braille spinner frames. Matches the `cli-spinners` "dots" preset
 /// (see `.design/loading.md`). 10 frames, advanced every 80ms while
@@ -748,67 +750,30 @@ impl Render for AuraView {
                 let uncloak = needs_uncloak.clone();
                 window.on_next_frame(move |window, _cx| {
                     window.resize(new_size);
-                    // On Windows: GPUI's resize() uses SWP_NOMOVE, which keeps
-                    // the window's top-left origin fixed and moves the bottom.
-                    // We want the bottom to stay flush with the taskbar, so we
-                    // reposition to `work_bottom - content_h - gap` after the
-                    // resize.  Both ops are spawned on the ForegroundExecutor
-                    // (FIFO): resize task runs first, then reposition+uncloak,
-                    // so DWM sees only the final state at the next vsync.
+                    // GPUI's resize() uses SWP_NOMOVE: it keeps the window's
+                    // top-left fixed and moves the bottom. A bottom-anchored
+                    // tray popup wants the opposite, so on Windows we move the
+                    // window back so its bottom hugs the taskbar (and lift the
+                    // open-time cloak). See platform::reposition_after_resize.
                     #[cfg(target_os = "windows")]
                     {
-                        let scale = window.scale_factor();
-                        let cur_x_phys =
-                            (f32::from(window.bounds().origin.x) * scale).round() as i32;
-                        let target_y_phys = if let Some(display) = _cx.primary_display() {
-                            let db = display.bounds();
-                            let full_bottom = f32::from(db.origin.y + db.size.height);
-                            let work_bottom = crate::work_area::available_bottom(db)
-                                .unwrap_or(full_bottom - 120.0);
-                            let y = work_bottom - f32::from(new_size.height) - 8.0;
-                            (y * scale).round() as i32
-                        } else {
-                            // No display info — fall back to sync uncloak only.
-                            if uncloak.replace(false) {
-                                crate::win32_set_cloak(window, false);
-                            }
-                            return;
-                        };
-                        let hwnd_val = window.hwnd();
-                        let do_uncloak = uncloak.replace(false);
-                        _cx.spawn(async move |_cx| {
-                            use windows::Win32::Foundation::HWND;
-                            use windows::Win32::UI::WindowsAndMessaging::{
-                                SetWindowPos, SWP_NOACTIVATE, SWP_NOSIZE, SWP_NOZORDER,
-                            };
-                            let hwnd = HWND(hwnd_val as *mut _);
-                            unsafe {
-                                let _ = SetWindowPos(
-                                    hwnd,
-                                    None,
-                                    cur_x_phys,
-                                    target_y_phys,
-                                    0,
-                                    0,
-                                    SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE,
-                                );
-                            }
-                            if do_uncloak {
-                                use windows::Win32::Graphics::Dwm::{
-                                    DwmSetWindowAttribute, DWMWA_CLOAK,
-                                };
-                                let val: i32 = 0;
-                                unsafe {
-                                    let _ = DwmSetWindowAttribute(
-                                        hwnd,
-                                        DWMWA_CLOAK,
-                                        std::ptr::addr_of!(val).cast(),
-                                        std::mem::size_of::<i32>() as u32,
-                                    );
-                                }
-                            }
-                        })
-                        .detach();
+                        // Desired top-left, computed *absolutely* from the work
+                        // area for the new content height — never read back from
+                        // the window's current position, which is what stops the
+                        // modal walking across the screen (issue #27).
+                        let desired = _cx.primary_display().map(|display| {
+                            let from_work = crate::placement::modal_origin(
+                                display.bounds(),
+                                None,
+                                f32::from(new_size.height),
+                            );
+                            // NOTE(#27): X is still taken from the live origin
+                            // here, which is the drift bug. The behavioural fix
+                            // is to use `from_work.x` instead — kept separate so
+                            // this refactor stays behaviour-preserving.
+                            gpui::point(window.bounds().origin.x, from_work.y)
+                        });
+                        crate::platform::reposition_after_resize(window, _cx, desired, &uncloak);
                     }
                 });
             });

--- a/crates/aura/src/main.rs
+++ b/crates/aura/src/main.rs
@@ -6,6 +6,7 @@ mod app;
 mod assets;
 mod cli;
 mod format;
+mod placement;
 mod platform;
 mod runtime;
 mod tray;
@@ -22,7 +23,7 @@ use anyhow::Result;
 use aura_core::{config::AppConfig, state::AppState};
 use clap::Parser;
 use gpui::{
-    div, point, prelude::*, px, size, Application, Bounds, IntoElement, Render, TitlebarOptions,
+    div, prelude::*, px, size, Application, Bounds, IntoElement, Render, TitlebarOptions,
     WindowBounds, WindowDecorations, WindowHandle, WindowKind, WindowOptions,
 };
 
@@ -375,69 +376,9 @@ async fn toggle(
         .flatten()
 }
 
-/// Modal dimensions and the gap we leave between its edges and the
-/// screen / panel. Width/height are intentionally fixed — the
-/// `app.rs::on_children_prepainted` resize callback shrinks the window
-/// vertically to fit content (capped at the available work area), so the
-/// initial 640 is just a sensible starting size that lets the first
-/// paint render without thrashing.
-const MODAL_W: f32 = 520.;
-const MODAL_H: f32 = 640.;
-const SCREEN_GAP: f32 = 8.;
-/// Defensive blind reserve for the bottom edge when
-/// [`crate::work_area::available_bottom`] returns `None` (non-KDE,
-/// non-Linux, or parse failure). Matches Strategy A's value so corner
-/// anchoring degrades to "Strategy A + bottom-right placement" instead
-/// of dumping the modal into a taskbar.
-#[cfg(not(target_os = "macos"))]
-const BLIND_BOTTOM_RESERVE: f32 = 120.;
-
-/// Compute where to place the modal window.
-///
-/// **macOS**: the tray icon lives in the menu bar at the top. We anchor the
-/// modal just below the bar, horizontally centred on the icon's X coord
-/// (from `hint`). Falls back to top-right if `hint` is absent.
-///
-/// **Linux / Windows**: anchors to the bottom-right of the available work
-/// area (above the taskbar/panel). Wayland compositors may ignore the
-/// requested origin and centre the window instead; users can override via a
-/// KWin window rule.
-fn compute_modal_bounds(cx: &mut gpui::App, _hint: Option<(i32, i32)>) -> Bounds<gpui::Pixels> {
-    let modal_size = size(px(MODAL_W), px(MODAL_H));
-
-    let Some(display) = cx.primary_display() else {
-        return Bounds::centered(None, modal_size, cx);
-    };
-    let display_bounds = display.bounds();
-
-    let screen_left = f32::from(display_bounds.origin.x);
-    let screen_top = f32::from(display_bounds.origin.y);
-    let screen_right = f32::from(display_bounds.origin.x + display_bounds.size.width);
-
-    #[cfg(target_os = "macos")]
-    {
-        // On macOS the tray sits in the menu bar (~25 pt tall). Place the
-        // modal just below it, horizontally centred on the click position.
-        // GPUI uses top-left origin with Y increasing downward on macOS.
-        const MENU_BAR_H: f32 = 25.0;
-        let icon_x = _hint
-            .map(|(x, _)| x as f32)
-            .unwrap_or(screen_right - MODAL_W / 2.0);
-        let x = (icon_x - MODAL_W / 2.0).clamp(screen_left, screen_right - MODAL_W);
-        let y = screen_top + MENU_BAR_H + SCREEN_GAP;
-        Bounds::new(point(px(x), px(y)), modal_size)
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    {
-        let screen_bottom_full = f32::from(display_bounds.origin.y + display_bounds.size.height);
-        let work_bottom = crate::work_area::available_bottom(display_bounds)
-            .unwrap_or(screen_bottom_full - BLIND_BOTTOM_RESERVE);
-        let x = (screen_right - MODAL_W - SCREEN_GAP).max(screen_left);
-        let y = (work_bottom - MODAL_H - SCREEN_GAP).max(screen_top);
-        Bounds::new(point(px(x), px(y)), modal_size)
-    }
-}
+// Modal geometry (size + anchor math) lives in `placement.rs` — the single
+// source of truth shared by `toggle_window` (open) and `app.rs`'s auto-fit
+// reposition. See that module for the per-OS anchoring rules.
 
 fn toggle_window(
     cx: &mut gpui::App,
@@ -462,7 +403,7 @@ fn toggle_window(
         AppState::default()
     });
 
-    let bounds = compute_modal_bounds(cx, hint);
+    let bounds = placement::modal_bounds(cx, hint);
     // `display.show_in_app_switcher` controls whether the modal appears in
     // the OS's "where are my windows" surfaces — Cmd+Tab + Dock on macOS,
     // Alt+Tab + taskbar on Windows, panel + window switcher on Linux.

--- a/crates/aura/src/main.rs
+++ b/crates/aura/src/main.rs
@@ -403,7 +403,8 @@ fn toggle_window(
         AppState::default()
     });
 
-    let bounds = placement::modal_bounds(cx, hint);
+    let anchor = placement::Anchor::from_config(&config.display.anchor);
+    let bounds = placement::modal_bounds(cx, hint, anchor);
     // `display.show_in_app_switcher` controls whether the modal appears in
     // the OS's "where are my windows" surfaces — Cmd+Tab + Dock on macOS,
     // Alt+Tab + taskbar on Windows, panel + window switcher on Linux.

--- a/crates/aura/src/placement.rs
+++ b/crates/aura/src/placement.rs
@@ -1,0 +1,107 @@
+//! Modal placement — the single source of truth for where the tray popup
+//! sits and how large it is.
+//!
+//! Placement is computed as an **absolute function of `(display work area,
+//! content height)`**. It deliberately never reads the window's *current*
+//! position: that is what makes the post-resize reposition idempotent.
+//! Reading the live origin back and feeding it into the next reposition is
+//! exactly the feedback loop that made the Windows modal "walk" across the
+//! screen on every click (issue #27) — keeping the math here, sourced only
+//! from the work area, removes any opportunity for that drift.
+//!
+//! Two callers share this module:
+//!
+//! 1. [`modal_bounds`] — `main.rs::toggle_window` uses it for the initial
+//!    window bounds at open (size + origin for the full [`MODAL_H`]).
+//! 2. [`modal_origin`] — `app.rs`'s auto-fit callback uses it to recompute
+//!    where the (now shorter) window should sit after it shrinks to the
+//!    measured content height. See `platform::reposition_after_resize`.
+
+use gpui::{point, px, size, Bounds, Pixels, Point, Size};
+
+/// Fixed modal width. The window grows vertically to fit content (see
+/// `app.rs::on_children_prepainted`), so only the height is dynamic.
+pub const MODAL_W: f32 = 520.0;
+
+/// Initial modal height at open. The auto-fit callback shrinks the window to
+/// the measured content height on the next frame, so this is just a sensible
+/// starting size that lets the first paint render without thrashing.
+pub const MODAL_H: f32 = 640.0;
+
+/// Gap between the modal and the nearest screen edge / taskbar.
+pub const SCREEN_GAP: f32 = 8.0;
+
+/// Defensive blind reserve for the bottom edge when
+/// [`crate::work_area::available_bottom`] returns `None` (non-KDE,
+/// non-Linux, or parse failure). Comfortably clears KDE Plasma's "Huge"
+/// panel preset (~120px) so corner anchoring degrades to "bottom-right
+/// placement minus a safe margin" instead of dumping the modal into a
+/// taskbar.
+#[cfg(not(target_os = "macos"))]
+pub const BLIND_BOTTOM_RESERVE: f32 = 120.0;
+
+/// The modal's size at open ([`MODAL_W`] × [`MODAL_H`]).
+pub fn modal_size() -> Size<Pixels> {
+    size(px(MODAL_W), px(MODAL_H))
+}
+
+/// Desired top-left of the modal, in the same logical-pixel space
+/// `App::primary_display` uses (origin at the display's top-left, Y
+/// increasing downward), for a window whose content is `content_h` pixels
+/// tall.
+///
+/// **macOS**: the tray icon lives in the menu bar at the top, so the modal
+/// anchors just below the bar (~25pt), horizontally centred on the icon's X
+/// coordinate (from `hint`). Independent of `content_h` — the window grows
+/// downward from a fixed top. Falls back to the top-right when `hint` is
+/// absent.
+///
+/// **Linux / Windows**: the tray icon lives at the bottom-right, so the
+/// modal anchors there — its bottom edge hugs the top of the taskbar/panel
+/// regardless of height, which is why `content_h` feeds the Y. Wayland
+/// compositors may ignore the requested origin and centre the window; users
+/// can override via a KWin window rule (see README "Modal placement on
+/// Wayland").
+pub fn modal_origin(
+    display: Bounds<Pixels>,
+    hint: Option<(i32, i32)>,
+    content_h: f32,
+) -> Point<Pixels> {
+    let screen_left = f32::from(display.origin.x);
+    let screen_top = f32::from(display.origin.y);
+    let screen_right = f32::from(display.origin.x + display.size.width);
+
+    #[cfg(target_os = "macos")]
+    {
+        let _ = content_h;
+        const MENU_BAR_H: f32 = 25.0;
+        let icon_x = hint
+            .map(|(x, _)| x as f32)
+            .unwrap_or(screen_right - MODAL_W / 2.0);
+        let x = (icon_x - MODAL_W / 2.0).clamp(screen_left, screen_right - MODAL_W);
+        let y = screen_top + MENU_BAR_H + SCREEN_GAP;
+        point(px(x), px(y))
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = hint;
+        let screen_bottom_full = f32::from(display.origin.y + display.size.height);
+        let work_bottom = crate::work_area::available_bottom(display)
+            .unwrap_or(screen_bottom_full - BLIND_BOTTOM_RESERVE);
+        let x = (screen_right - MODAL_W - SCREEN_GAP).max(screen_left);
+        let y = (work_bottom - content_h - SCREEN_GAP).max(screen_top);
+        point(px(x), px(y))
+    }
+}
+
+/// The modal's full bounds at open: [`modal_size`] anchored at
+/// [`modal_origin`] for the full [`MODAL_H`]. Falls back to screen-centred
+/// when there is no primary display.
+pub fn modal_bounds(cx: &mut gpui::App, hint: Option<(i32, i32)>) -> Bounds<Pixels> {
+    let size = modal_size();
+    let Some(display) = cx.primary_display() else {
+        return Bounds::centered(None, size, cx);
+    };
+    Bounds::new(modal_origin(display.bounds(), hint, MODAL_H), size)
+}

--- a/crates/aura/src/placement.rs
+++ b/crates/aura/src/placement.rs
@@ -2,20 +2,23 @@
 //! sits and how large it is.
 //!
 //! Placement is computed as an **absolute function of `(display work area,
-//! content height)`**. It deliberately never reads the window's *current*
-//! position: that is what makes the post-resize reposition idempotent.
-//! Reading the live origin back and feeding it into the next reposition is
-//! exactly the feedback loop that made the Windows modal "walk" across the
-//! screen on every click (issue #27) — keeping the math here, sourced only
-//! from the work area, removes any opportunity for that drift.
+//! content height, anchor)`**. It deliberately never reads the window's
+//! *current* position: that is what makes the post-resize reposition
+//! idempotent. Reading the live origin back and feeding it into the next
+//! reposition is exactly the feedback loop that made the Windows modal "walk"
+//! across the screen on every click (issue #27) — keeping the math here,
+//! sourced only from the work area, removes any opportunity for that drift.
 //!
-//! Two callers share this module:
+//! The [`Anchor`] (from `display.anchor` in the config) selects how the modal
+//! behaves as it auto-fits its content height. Two callers share the module:
 //!
 //! 1. [`modal_bounds`] — `main.rs::toggle_window` uses it for the initial
 //!    window bounds at open (size + origin for the full [`MODAL_H`]).
 //! 2. [`modal_origin`] — `app.rs`'s auto-fit callback uses it to recompute
 //!    where the (now shorter) window should sit after it shrinks to the
-//!    measured content height. See `platform::reposition_after_resize`.
+//!    measured content height. Only [`Anchor::Bottom`] actually repositions
+//!    (see [`Anchor::needs_reposition`] and `platform::reposition_after_resize`
+//!    / `platform::set_window_origin`).
 
 use gpui::{point, px, size, Bounds, Pixels, Point, Size};
 
@@ -34,11 +37,66 @@ pub const SCREEN_GAP: f32 = 8.0;
 /// Defensive blind reserve for the bottom edge when
 /// [`crate::work_area::available_bottom`] returns `None` (non-KDE,
 /// non-Linux, or parse failure). Comfortably clears KDE Plasma's "Huge"
-/// panel preset (~120px) so corner anchoring degrades to "bottom-right
+/// panel preset (~120px) so bottom anchoring degrades to "bottom-right
 /// placement minus a safe margin" instead of dumping the modal into a
 /// taskbar.
-#[cfg(not(target_os = "macos"))]
 pub const BLIND_BOTTOM_RESERVE: f32 = 120.0;
+
+/// Approximate height of the macOS menu bar, cleared by [`Anchor::Top`].
+#[cfg(target_os = "macos")]
+const MENU_BAR_H: f32 = 25.0;
+
+/// How the modal anchors as it auto-fits its content height. Parsed from the
+/// `display.anchor` config string (see [`Anchor::from_config`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Anchor {
+    /// Open at the platform's natural tray corner and grow downward from
+    /// there (GPUI's default resize behaviour); never reposition after a
+    /// resize. Safe on Wayland, where the compositor owns placement.
+    None,
+    /// Pin the bottom edge above a bottom taskbar so the modal grows *upward*.
+    /// GPUI's `resize()` keeps the top fixed and grows downward, so this is
+    /// the only anchor that needs an active post-resize move.
+    Bottom,
+    /// Pin the top edge just below a top panel / menu bar and grow downward.
+    /// No active move needed — GPUI already grows down from a fixed top.
+    Top,
+}
+
+impl Anchor {
+    /// Per-OS default, baked in at compile time for this target. Mirrors
+    /// `aura_core::config::default_anchor` (kept in sync by value, since the
+    /// two live in different crates).
+    pub fn os_default() -> Self {
+        #[cfg(target_os = "windows")]
+        {
+            Anchor::Bottom
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            Anchor::None
+        }
+    }
+
+    /// Parse the `display.anchor` config string. Unrecognised values
+    /// (including the legacy `"auto"`) fall back to the per-OS default so old
+    /// configs keep working.
+    pub fn from_config(s: &str) -> Self {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "none" => Anchor::None,
+            "bottom" => Anchor::Bottom,
+            "top" => Anchor::Top,
+            _ => Self::os_default(),
+        }
+    }
+
+    /// Whether this anchor needs an active reposition after the auto-fit
+    /// resize. Only [`Anchor::Bottom`] does: GPUI keeps the top fixed and
+    /// grows downward, so a bottom-pinned window must be moved back up.
+    pub fn needs_reposition(self) -> bool {
+        matches!(self, Anchor::Bottom)
+    }
+}
 
 /// The modal's size at open ([`MODAL_W`] × [`MODAL_H`]).
 pub fn modal_size() -> Size<Pixels> {
@@ -48,60 +106,88 @@ pub fn modal_size() -> Size<Pixels> {
 /// Desired top-left of the modal, in the same logical-pixel space
 /// `App::primary_display` uses (origin at the display's top-left, Y
 /// increasing downward), for a window whose content is `content_h` pixels
-/// tall.
+/// tall under `anchor`.
 ///
-/// **macOS**: the tray icon lives in the menu bar at the top, so the modal
-/// anchors just below the bar (~25pt), horizontally centred on the icon's X
-/// coordinate (from `hint`). Independent of `content_h` — the window grows
-/// downward from a fixed top. Falls back to the top-right when `hint` is
-/// absent.
+/// Horizontal placement: macOS centres on the tray-icon click (the tray lives
+/// in the menu bar), so `hint` is the click X; every other platform's tray
+/// sits in a screen corner, so the modal right-aligns and `hint` is ignored.
 ///
-/// **Linux / Windows**: the tray icon lives at the bottom-right, so the
-/// modal anchors there — its bottom edge hugs the top of the taskbar/panel
-/// regardless of height, which is why `content_h` feeds the Y. Wayland
-/// compositors may ignore the requested origin and centre the window; users
-/// can override via a KWin window rule (see README "Modal placement on
-/// Wayland").
+/// Vertical placement follows `anchor` (see [`Anchor`]). `Anchor::None` uses
+/// the platform-natural corner — top (below the menu bar) on macOS, bottom on
+/// Windows/Linux — and is never repositioned afterwards.
 pub fn modal_origin(
     display: Bounds<Pixels>,
     hint: Option<(i32, i32)>,
     content_h: f32,
+    anchor: Anchor,
 ) -> Point<Pixels> {
     let screen_left = f32::from(display.origin.x);
     let screen_top = f32::from(display.origin.y);
     let screen_right = f32::from(display.origin.x + display.size.width);
+    let screen_bottom_full = f32::from(display.origin.y + display.size.height);
 
     #[cfg(target_os = "macos")]
-    {
-        let _ = content_h;
-        const MENU_BAR_H: f32 = 25.0;
+    let x = {
         let icon_x = hint
             .map(|(x, _)| x as f32)
             .unwrap_or(screen_right - MODAL_W / 2.0);
-        let x = (icon_x - MODAL_W / 2.0).clamp(screen_left, screen_right - MODAL_W);
-        let y = screen_top + MENU_BAR_H + SCREEN_GAP;
-        point(px(x), px(y))
-    }
-
+        (icon_x - MODAL_W / 2.0).clamp(screen_left, screen_right - MODAL_W)
+    };
     #[cfg(not(target_os = "macos"))]
-    {
+    let x = {
         let _ = hint;
-        let screen_bottom_full = f32::from(display.origin.y + display.size.height);
+        (screen_right - MODAL_W - SCREEN_GAP).max(screen_left)
+    };
+
+    let bottom_y = || {
         let work_bottom = crate::work_area::available_bottom(display)
             .unwrap_or(screen_bottom_full - BLIND_BOTTOM_RESERVE);
-        let x = (screen_right - MODAL_W - SCREEN_GAP).max(screen_left);
-        let y = (work_bottom - content_h - SCREEN_GAP).max(screen_top);
-        point(px(x), px(y))
-    }
+        (work_bottom - content_h - SCREEN_GAP).max(screen_top)
+    };
+    let top_y = || {
+        // macOS clears the menu bar; elsewhere we sit at the top of the
+        // display. We only detect *bottom* panel reservations today, so on a
+        // Linux setup with a top panel this can land under it — documented in
+        // docs/configuration.md.
+        #[cfg(target_os = "macos")]
+        {
+            screen_top + MENU_BAR_H + SCREEN_GAP
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            screen_top + SCREEN_GAP
+        }
+    };
+
+    let y = match anchor {
+        Anchor::Bottom => bottom_y(),
+        Anchor::Top => top_y(),
+        Anchor::None => {
+            #[cfg(target_os = "macos")]
+            {
+                top_y()
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                bottom_y()
+            }
+        }
+    };
+
+    point(px(x), px(y))
 }
 
 /// The modal's full bounds at open: [`modal_size`] anchored at
 /// [`modal_origin`] for the full [`MODAL_H`]. Falls back to screen-centred
 /// when there is no primary display.
-pub fn modal_bounds(cx: &mut gpui::App, hint: Option<(i32, i32)>) -> Bounds<Pixels> {
+pub fn modal_bounds(
+    cx: &mut gpui::App,
+    hint: Option<(i32, i32)>,
+    anchor: Anchor,
+) -> Bounds<Pixels> {
     let size = modal_size();
     let Some(display) = cx.primary_display() else {
         return Bounds::centered(None, size, cx);
     };
-    Bounds::new(modal_origin(display.bounds(), hint, MODAL_H), size)
+    Bounds::new(modal_origin(display.bounds(), hint, MODAL_H, anchor), size)
 }

--- a/crates/aura/src/platform.rs
+++ b/crates/aura/src/platform.rs
@@ -252,26 +252,32 @@ pub fn raise_window_to_floating(window: &mut gpui::Window) {
 }
 
 // ── Window repositioning after auto-fit resize ──────────────────────────────
+//
+// GPUI 0.2's `Window::resize` issues `SetWindowPos(.., SWP_NOMOVE)`, which
+// keeps the window's top-left fixed and grows/shrinks the bottom. For an
+// `Anchor::Bottom` modal we want the opposite — the bottom edge should stay
+// flush with the taskbar — so after the resize we move the top-left to the
+// freshly computed `placement::modal_origin`.
+//
+// `desired_origin` MUST be computed absolutely from the work area, never read
+// back from the window's current position: that absoluteness is what keeps
+// repeated calls idempotent instead of letting the window walk across the
+// screen (issue #27).
+//
+// Two entry points, picked by the caller's `#[cfg]`:
+//   - Windows: `reposition_after_resize` — also carries the open-time DWM
+//     uncloak, which must fire after the resize in *every* anchor mode.
+//   - macOS / Linux: `set_window_origin` — a plain move, called only when
+//     there's a target (`Anchor::Bottom`).
 
-/// Move the modal so it stays anchored after the auto-fit `Window::resize`
-/// shrinks it to the measured content height, and lift the open-time DWM
-/// cloak once it's in place.
+/// Windows: move the modal to `desired_origin` (when `Some`) and lift the
+/// open-time DWM cloak, both after the auto-fit resize.
 ///
-/// GPUI 0.2's `Window::resize` issues `SetWindowPos(.., SWP_NOMOVE)`, which
-/// keeps the window's top-left fixed and grows/shrinks the bottom. For a
-/// bottom-anchored tray popup we want the opposite — the bottom edge should
-/// stay flush with the taskbar — so we reposition the top-left to
-/// `desired_origin` after the resize.
-///
-/// `desired_origin` MUST be computed absolutely from the work area
-/// ([`crate::placement::modal_origin`]), never read back from the window's
-/// current position: a `None` means "no display info, skip the move". This
-/// absoluteness is what keeps repeated calls idempotent instead of letting
-/// the window walk across the screen (issue #27).
-///
-/// Ordering: `resize` (the caller) and the `SetWindowPos` + uncloak here both
-/// run on the `ForegroundExecutor` (FIFO), so DWM only ever composites the
-/// final state — the user never sees the intermediate size or position.
+/// `desired_origin` is `None` for non-repositioning anchors (`none`/`top`) or
+/// when no display info is available; in that case the window keeps the
+/// top-left GPUI's resize left it and we only uncloak. `resize` (the caller)
+/// and the `SetWindowPos` + uncloak here all run on the `ForegroundExecutor`
+/// (FIFO), so DWM only ever composites the final state — no flash, no jump.
 #[cfg(target_os = "windows")]
 pub(crate) fn reposition_after_resize(
     window: &mut gpui::Window,
@@ -280,36 +286,36 @@ pub(crate) fn reposition_after_resize(
     uncloak: &std::rc::Rc<std::cell::Cell<bool>>,
 ) {
     let scale = window.scale_factor();
-    let Some(origin) = desired_origin else {
-        // No display info — there's nothing to anchor against, so just lift
-        // the cloak synchronously and bail (the window stays where GPUI's
-        // resize left it).
-        if uncloak.replace(false) {
-            crate::win32_set_cloak(window, false);
-        }
-        return;
-    };
-    let x_phys = (f32::from(origin.x) * scale).round() as i32;
-    let y_phys = (f32::from(origin.y) * scale).round() as i32;
-    let hwnd_val = window.hwnd();
+    let move_to = desired_origin.map(|origin| {
+        (
+            (f32::from(origin.x) * scale).round() as i32,
+            (f32::from(origin.y) * scale).round() as i32,
+        )
+    });
     let do_uncloak = uncloak.replace(false);
+    if move_to.is_none() && !do_uncloak {
+        return;
+    }
+    let hwnd_val = window.hwnd();
 
     cx.spawn(async move |_cx| {
         use windows::Win32::Foundation::HWND;
-        use windows::Win32::UI::WindowsAndMessaging::{
-            SetWindowPos, SWP_NOACTIVATE, SWP_NOSIZE, SWP_NOZORDER,
-        };
         let hwnd = HWND(hwnd_val as *mut _);
-        unsafe {
-            let _ = SetWindowPos(
-                hwnd,
-                None,
-                x_phys,
-                y_phys,
-                0,
-                0,
-                SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE,
-            );
+        if let Some((x_phys, y_phys)) = move_to {
+            use windows::Win32::UI::WindowsAndMessaging::{
+                SetWindowPos, SWP_NOACTIVATE, SWP_NOSIZE, SWP_NOZORDER,
+            };
+            unsafe {
+                let _ = SetWindowPos(
+                    hwnd,
+                    None,
+                    x_phys,
+                    y_phys,
+                    0,
+                    0,
+                    SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE,
+                );
+            }
         }
         if do_uncloak {
             use windows::Win32::Graphics::Dwm::{DwmSetWindowAttribute, DWMWA_CLOAK};
@@ -325,6 +331,137 @@ pub(crate) fn reposition_after_resize(
         }
     })
     .detach();
+}
+
+/// macOS: move the modal's top-left to `origin` (logical points, top-left
+/// origin, Y down — the space `placement` works in). Used for
+/// `Anchor::Bottom`, which on macOS is an explicit non-default choice (the
+/// tray lives in the menu bar up top).
+///
+/// AppKit uses a bottom-left screen origin with Y measured upward, so we flip
+/// against the main screen's height and call `setFrameTopLeftPoint:`.
+#[cfg(target_os = "macos")]
+pub(crate) fn set_window_origin(
+    window: &mut gpui::Window,
+    _cx: &mut gpui::App,
+    origin: gpui::Point<gpui::Pixels>,
+) {
+    use cocoa::foundation::{NSPoint, NSRect};
+    use objc::{class, msg_send, sel, sel_impl};
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+
+    let Ok(wh) = <gpui::Window as HasWindowHandle>::window_handle(window) else {
+        return;
+    };
+    let RawWindowHandle::AppKit(h) = wh.as_raw() else {
+        return;
+    };
+    unsafe {
+        let ns_view = h.ns_view.as_ptr() as cocoa::base::id;
+        let ns_window: cocoa::base::id = msg_send![ns_view, window];
+        if ns_window.is_null() {
+            return;
+        }
+        let screen: cocoa::base::id = msg_send![class!(NSScreen), mainScreen];
+        if screen.is_null() {
+            return;
+        }
+        let frame: NSRect = msg_send![screen, frame];
+        // Flip GPUI's top-down Y into AppKit's bottom-up screen Y.
+        let top_left = NSPoint::new(
+            f64::from(f32::from(origin.x)),
+            frame.size.height - f64::from(f32::from(origin.y)),
+        );
+        let _: () = msg_send![ns_window, setFrameTopLeftPoint: top_left];
+    }
+}
+
+/// Linux: move the modal's top-left to `origin` (logical points). GPUI 0.2
+/// exposes no move API, so we issue an X11 `ConfigureWindow` ourselves against
+/// the XCB window id.
+///
+/// This works on **X11** (KWin honours position requests for our notification-
+/// type popup, the same way it honours GPUI's open position). On **Wayland**
+/// the window handle is a Wayland surface, not an XCB id — the match below
+/// falls through and we log the limitation once, because the Wayland protocol
+/// forbids clients from positioning their own toplevels (use a KWin window
+/// rule instead; see docs/configuration.md).
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+pub(crate) fn set_window_origin(
+    window: &mut gpui::Window,
+    _cx: &mut gpui::App,
+    origin: gpui::Point<gpui::Pixels>,
+) {
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+
+    let scale = window.scale_factor();
+    let Ok(wh) = <gpui::Window as HasWindowHandle>::window_handle(window) else {
+        return;
+    };
+    let RawWindowHandle::Xcb(h) = wh.as_raw() else {
+        // Wayland (or some other backend) — can't reposition. Warn once.
+        static WARNED: std::sync::Once = std::sync::Once::new();
+        WARNED.call_once(|| {
+            eprintln!(
+                "aura: display.anchor = \"bottom\" has no live reposition on \
+                 Wayland (the compositor owns window placement); the modal \
+                 opens bottom-anchored but grows downward. See \
+                 docs/configuration.md."
+            );
+        });
+        return;
+    };
+
+    // X11 window coordinates are physical, root-relative pixels; GPUI gives us
+    // logical points, so scale up (scale is 1.0 on most X11/KDE setups).
+    let x = (f32::from(origin.x) * scale).round() as i32;
+    let y = (f32::from(origin.y) * scale).round() as i32;
+    let xid = h.window.get();
+
+    // Fresh short-lived connection: repositioning only fires when the content
+    // height changes (tab switch / refresh), so the handshake cost is
+    // negligible and we avoid caching a connection that could go stale. The
+    // XID is server-global, so our own connection can address it.
+    let Ok((conn, screen_num)) = x11rb::connect(None) else {
+        return;
+    };
+    use x11rb::connection::Connection;
+    use x11rb::protocol::xproto::{
+        ClientMessageEvent, ConfigureWindowAux, ConnectionExt, EventMask,
+    };
+
+    // A plain ConfigureWindow moves *override-redirect* / unmanaged windows
+    // (and is honoured by some minimal WMs), but a full window manager like
+    // KWin owns the geometry of managed top-levels and silently ignores a
+    // client's attempt to move itself this way after the window is mapped.
+    // It still honours it for the unmanaged case, so issue it regardless.
+    let _ = conn.configure_window(xid, &ConfigureWindowAux::new().x(x).y(y));
+
+    // The EWMH-blessed way for a client to move its *own managed* window:
+    // post a `_NET_MOVERESIZE_WINDOW` ClientMessage to the root with
+    // SubstructureRedirect set, which the WM (KWin, Mutter, …) processes and
+    // applies. This is what actually makes `anchor = "bottom"` hug the
+    // taskbar under KWin. data = [flags, x, y, w, h]; the flags carry the
+    // gravity (0 = use the window's win-gravity), which axes are present
+    // (bits 8/9 = x/y), and the source indication (bit 12 = normal app).
+    if let Ok(cookie) = conn.intern_atom(false, b"_NET_MOVERESIZE_WINDOW") {
+        if let Ok(reply) = cookie.reply() {
+            const X_PRESENT: u32 = 1 << 8;
+            const Y_PRESENT: u32 = 1 << 9;
+            const SOURCE_APP: u32 = 1 << 12;
+            let flags = X_PRESENT | Y_PRESENT | SOURCE_APP;
+            let root = conn.setup().roots[screen_num].root;
+            let event =
+                ClientMessageEvent::new(32, xid, reply.atom, [flags, x as u32, y as u32, 0, 0]);
+            let _ = conn.send_event(
+                false,
+                root,
+                EventMask::SUBSTRUCTURE_REDIRECT | EventMask::SUBSTRUCTURE_NOTIFY,
+                event,
+            );
+        }
+    }
+    let _ = conn.flush();
 }
 
 // ── Open with system handler (file or URL) ──────────────────────────────────

--- a/crates/aura/src/platform.rs
+++ b/crates/aura/src/platform.rs
@@ -377,8 +377,8 @@ pub(crate) fn set_window_origin(
 }
 
 /// Linux: move the modal's top-left to `origin` (logical points). GPUI 0.2
-/// exposes no move API, so we issue an X11 `ConfigureWindow` ourselves against
-/// the XCB window id.
+/// exposes no move API, so we issue an X11 move ourselves against the XCB
+/// window id.
 ///
 /// This works on **X11** (KWin honours position requests for our notification-
 /// type popup, the same way it honours GPUI's open position). On **Wayland**
@@ -386,6 +386,13 @@ pub(crate) fn set_window_origin(
 /// falls through and we log the limitation once, because the Wayland protocol
 /// forbids clients from positioning their own toplevels (use a KWin window
 /// rule instead; see docs/configuration.md).
+///
+/// This only *moves* the window; the caller is responsible for the resize
+/// (GPUI's `window.resize()`). The two are sequenced by the caller so that the
+/// window never crosses the taskbar mid-transition (see the call site in
+/// `app.rs`): a combined move+resize via `_NET_MOVERESIZE_WINDOW` was tried and
+/// reverted because KWin honours that message's *move* bits but silently drops
+/// its *size* bits, leaving the modal stuck at its initial height.
 #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
 pub(crate) fn set_window_origin(
     window: &mut gpui::Window,

--- a/crates/aura/src/platform.rs
+++ b/crates/aura/src/platform.rs
@@ -251,6 +251,82 @@ pub fn raise_window_to_floating(window: &mut gpui::Window) {
     }
 }
 
+// ── Window repositioning after auto-fit resize ──────────────────────────────
+
+/// Move the modal so it stays anchored after the auto-fit `Window::resize`
+/// shrinks it to the measured content height, and lift the open-time DWM
+/// cloak once it's in place.
+///
+/// GPUI 0.2's `Window::resize` issues `SetWindowPos(.., SWP_NOMOVE)`, which
+/// keeps the window's top-left fixed and grows/shrinks the bottom. For a
+/// bottom-anchored tray popup we want the opposite — the bottom edge should
+/// stay flush with the taskbar — so we reposition the top-left to
+/// `desired_origin` after the resize.
+///
+/// `desired_origin` MUST be computed absolutely from the work area
+/// ([`crate::placement::modal_origin`]), never read back from the window's
+/// current position: a `None` means "no display info, skip the move". This
+/// absoluteness is what keeps repeated calls idempotent instead of letting
+/// the window walk across the screen (issue #27).
+///
+/// Ordering: `resize` (the caller) and the `SetWindowPos` + uncloak here both
+/// run on the `ForegroundExecutor` (FIFO), so DWM only ever composites the
+/// final state — the user never sees the intermediate size or position.
+#[cfg(target_os = "windows")]
+pub(crate) fn reposition_after_resize(
+    window: &mut gpui::Window,
+    cx: &mut gpui::App,
+    desired_origin: Option<gpui::Point<gpui::Pixels>>,
+    uncloak: &std::rc::Rc<std::cell::Cell<bool>>,
+) {
+    let scale = window.scale_factor();
+    let Some(origin) = desired_origin else {
+        // No display info — there's nothing to anchor against, so just lift
+        // the cloak synchronously and bail (the window stays where GPUI's
+        // resize left it).
+        if uncloak.replace(false) {
+            crate::win32_set_cloak(window, false);
+        }
+        return;
+    };
+    let x_phys = (f32::from(origin.x) * scale).round() as i32;
+    let y_phys = (f32::from(origin.y) * scale).round() as i32;
+    let hwnd_val = window.hwnd();
+    let do_uncloak = uncloak.replace(false);
+
+    cx.spawn(async move |_cx| {
+        use windows::Win32::Foundation::HWND;
+        use windows::Win32::UI::WindowsAndMessaging::{
+            SetWindowPos, SWP_NOACTIVATE, SWP_NOSIZE, SWP_NOZORDER,
+        };
+        let hwnd = HWND(hwnd_val as *mut _);
+        unsafe {
+            let _ = SetWindowPos(
+                hwnd,
+                None,
+                x_phys,
+                y_phys,
+                0,
+                0,
+                SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE,
+            );
+        }
+        if do_uncloak {
+            use windows::Win32::Graphics::Dwm::{DwmSetWindowAttribute, DWMWA_CLOAK};
+            let val: i32 = 0;
+            unsafe {
+                let _ = DwmSetWindowAttribute(
+                    hwnd,
+                    DWMWA_CLOAK,
+                    std::ptr::addr_of!(val).cast(),
+                    std::mem::size_of::<i32>() as u32,
+                );
+            }
+        }
+    })
+    .detach();
+}
+
 // ── Open with system handler (file or URL) ──────────────────────────────────
 
 /// Open a filesystem path with the desktop's default handler, falling back to

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,10 +81,35 @@ default_period = "today"
 # [] to keep the default ordering.
 plugin_order = ["Hello", "RTK Gains"]
 
-# Where to anchor the modal relative to the widget click position
-# Options: "auto" | "top" | "bottom" | "left" | "right"
-# "auto" lets Aura pick based on available screen space
-anchor = "auto"
+# How the modal anchors as it auto-fits its content height.
+# Options:
+#   "none"   — open at the platform's natural tray corner and grow downward
+#              from there; never reposition after a resize. Safe on Wayland,
+#              where the compositor owns window placement.
+#   "bottom" — pin the bottom edge above a bottom taskbar so the modal grows
+#              *upward* (the tray-popup feel next to a bottom tray). Needs an
+#              active window move after each resize: supported on Windows,
+#              macOS, and Linux/X11. On Linux/Wayland it only applies at open
+#              (the compositor owns placement — see note below).
+#   "top"    — pin the top edge just below a top panel / menu bar and grow
+#              downward.
+# Default is OS-specific and written for you at install: "bottom" on Windows
+# (bottom taskbar), "none" on macOS and Linux. Unrecognised values (including
+# the legacy "auto") fall back to the per-OS default.
+anchor = "bottom"
+
+# Show OS-native window chrome (title bar + min/max/close) and let the user
+# resize the modal by dragging its edges. Default false — Aura behaves like a
+# fixed-width tray popup that auto-fits its height. Turning this on also
+# disables the auto-fit (so a dragged size sticks) and puts the modal in the
+# taskbar / alt-tab list.
+window_chrome = false
+
+# Optional upper bound (logical px) on the auto-fit height. The modal is
+# already capped at the screen's available work area; this imposes a tighter
+# ceiling. Omit (or leave unset) for "only the work-area cap applies".
+# Ignored when window_chrome = true (auto-fit is off then).
+# max_height = 500
 
 # Auto-close the modal when it loses focus (click outside, switch app).
 # Default true — matches typical menu-bar / tray-popup behaviour. Set
@@ -101,6 +126,33 @@ dismiss_on_focus_loss = true
 # takes effect without restarting the service.
 show_in_app_switcher = false
 ```
+
+### Modal anchoring (`anchor`)
+
+`anchor` controls which edge of the modal stays put as it auto-fits its
+content height:
+
+| Value | Behavior | Default on |
+|---|---|---|
+| `none` | Opens at the platform's natural tray corner and grows downward; never repositioned. | macOS, Linux |
+| `bottom` | Bottom edge pinned above a bottom taskbar; grows upward. | Windows |
+| `top` | Top edge pinned just below a top panel / menu bar; grows downward. | — |
+
+The right default is written to your config at install time based on your OS,
+so most people never need to set this. Change it if your taskbar/panel is
+somewhere other than your platform's default (e.g. a Linux desktop with a
+**top** panel → `anchor = "top"`).
+
+**Linux note:** on **X11**, `anchor = "bottom"` repositions live — Aura issues
+an X11 `ConfigureWindow` against its own window after each resize, which KWin
+honours, so the modal hugs the bottom taskbar as it shrinks. On **Wayland**
+the protocol forbids clients from positioning their own toplevels, so `bottom`
+only applies at *open*; as the modal shrinks it grows downward from there
+rather than hugging the taskbar. For exact placement on KDE Plasma / Wayland,
+use a KWin window rule (see
+[Modal placement on Wayland](../README.md#modal-placement-on-wayland) in the
+README). We currently detect only *bottom* panel reservations, so `top` on a
+Linux top-panel setup approximates by sitting at the very top of the display.
 
 ## Agent kinds
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,16 +143,21 @@ so most people never need to set this. Change it if your taskbar/panel is
 somewhere other than your platform's default (e.g. a Linux desktop with a
 **top** panel → `anchor = "top"`).
 
-**Linux note:** on **X11**, `anchor = "bottom"` repositions live — Aura issues
-an X11 `ConfigureWindow` against its own window after each resize, which KWin
-honours, so the modal hugs the bottom taskbar as it shrinks. On **Wayland**
-the protocol forbids clients from positioning their own toplevels, so `bottom`
-only applies at *open*; as the modal shrinks it grows downward from there
-rather than hugging the taskbar. For exact placement on KDE Plasma / Wayland,
-use a KWin window rule (see
+**Linux note:** on **X11**, `anchor = "bottom"` repositions live — after each
+resize Aura asks the window manager to move the modal via an EWMH
+`_NET_MOVERESIZE_WINDOW` request (a plain `ConfigureWindow` is ignored by KWin
+for a managed top-level), so the modal hugs the bottom taskbar as it
+grows/shrinks. On **Wayland** the protocol forbids clients from positioning
+their own toplevels, so `bottom` only applies at *open*; as the modal shrinks
+it grows downward from there rather than hugging the taskbar. For exact
+placement on KDE Plasma / Wayland, use a KWin window rule (see
 [Modal placement on Wayland](../README.md#modal-placement-on-wayland) in the
 README). We currently detect only *bottom* panel reservations, so `top` on a
 Linux top-panel setup approximates by sitting at the very top of the display.
+
+> **KDE Plasma:** if the modal *visibly stretches/animates* over ~0.5s as it
+> resizes, that is KWin's Morphing Popups effect, not Aura — see
+> [Troubleshooting: modal stretches on resize](troubleshooting/modal-stretches-on-resize-kde.md).
 
 ## Agent kinds
 

--- a/docs/troubleshooting/modal-stretches-on-resize-kde.md
+++ b/docs/troubleshooting/modal-stretches-on-resize-kde.md
@@ -1,0 +1,108 @@
+---
+title: "Troubleshooting: modal stretches / animates when it resizes (KDE Plasma)"
+status: draft
+version: 0.1.0
+last_updated: 2026-05-29
+last_verified: 2026-05-29
+source_refs:
+  - crates/aura/src/app.rs
+  - crates/aura/src/platform.rs
+  - crates/aura/src/placement.rs
+  - vendor/gpui/src/platform/linux/x11/window.rs
+owner: "@rfluid"
+tags: [troubleshooting, linux, kde, docs]
+---
+
+# Modal stretches / animates when it resizes (KDE Plasma)
+
+## Symptom
+
+On KDE Plasma, when the Aura modal changes height — on open, when switching
+tabs/periods, or when `anchor = "bottom"` grows it upward — the window's
+**contents visibly stretch vertically** and the resize plays out over roughly
+**0.3–1 second** instead of snapping to the new size instantly. Text looks
+squashed/stretched mid-animation, then "normalizes" once the window settles.
+
+This is purely cosmetic — placement is correct and the final size is correct —
+but the animation feels sluggish, especially for the bottom-anchored
+grow-upward behaviour where you want the resize to look instant.
+
+## Cause
+
+It is **not** an Aura animation — Aura has no resize transition. It is KWin's
+**Morphing Popups** desktop effect (`kwin4_effect_morphingpopups`), which is
+enabled by default on Plasma. That effect smoothly cross-fades/stretches the
+geometry of *popup-type* windows (tooltips, combo-box dropdowns, notifications)
+as they change size.
+
+Aura's modal is created as a popup: GPUI maps `WindowKind::PopUp` to
+`_NET_WM_WINDOW_TYPE_NOTIFICATION` (see
+`vendor/gpui/src/platform/linux/x11/window.rs`), and KWin treats notification
+windows as popups for this effect. So every resize of the modal gets morphed —
+KWin scales the old window buffer to the new size while it animates, which is
+the vertical "stretch" you see.
+
+## Confirm it
+
+```bash
+# qdbus6 on Qt6 Plasma; qdbus on older setups.
+qdbus6 org.kde.KWin /Effects org.kde.kwin.Effects.isEffectLoaded morphingpopups \
+  || qdbus org.kde.KWin /Effects org.kde.kwin.Effects.isEffectLoaded morphingpopups
+# -> "true" means the effect is active and is the cause.
+```
+
+You can prove it live by unloading the effect for the current session (no
+config change, reverts on next login or `reconfigure`):
+
+```bash
+qdbus org.kde.KWin /Effects org.kde.kwin.Effects.unloadEffect morphingpopups
+```
+
+Open the modal and switch tabs — the stretch should be gone. To restore it:
+
+```bash
+qdbus org.kde.KWin /Effects org.kde.kwin.Effects.loadEffect morphingpopups
+# or just:
+qdbus org.kde.KWin /KWin reconfigure
+```
+
+## Fix
+
+### Option A — System Settings (GUI, persistent)
+
+1. Open **System Settings** and search for **Desktop Effects**.
+2. Under the **Appearance** category, find **Morphing Popups**.
+3. Untick it and **Apply**.
+
+This makes tooltips and combo-box dropdowns resize instantly too — a very
+minor cosmetic change most people never notice.
+
+### Option B — command line (persistent)
+
+```bash
+# Qt6 Plasma:
+kwriteconfig6 --file kwinrc --group Plugins --key morphingpopupsEnabled false
+# Qt5 Plasma:  kwriteconfig5 --file kwinrc --group Plugins --key morphingpopupsEnabled false
+
+# Apply without logging out:
+qdbus org.kde.KWin /KWin reconfigure
+```
+
+Revert by setting the key to `true` (or deleting it) and running
+`reconfigure` again.
+
+## Notes & scope
+
+- **This is KDE/KWin-specific.** Windows and macOS have no equivalent
+  resize animation on the modal; their repositions are already instant.
+- **Aura does not change this for you.** Disabling Morphing Popups is a
+  *global* KWin setting that also affects unrelated tooltips and dropdowns,
+  so the installer deliberately does not touch it — it is left as an opt-in
+  user choice documented here.
+- **This is separate from placement.** If the modal opens in the wrong
+  corner or does not hug the taskbar, that is the `anchor` setting, not this
+  effect — see [Modal anchoring](../configuration.md#modal-anchoring-anchor)
+  and the Wayland note in [configuration.md](../configuration.md).
+- **Wayland:** the same effect applies, but on Wayland Aura cannot reposition
+  itself after a resize anyway (the compositor owns placement), so the
+  bottom-anchored grow-upward behaviour is X11-only regardless.

--- a/install.sh
+++ b/install.sh
@@ -16,8 +16,9 @@
 #   Windows (see scripts/install.ps1): aura.exe + Startup-folder shortcut
 #           (runs at sign-in) + Start Menu shortcut
 #
-# Override detection with AURA_INSTALL_MODE=source|release.
-# Pin a specific release with AURA_VERSION=v1.2.3.
+# Override detection with AURA_INSTALL_MODE=source|release or --mode.
+# Build a source checkout from a branch with AURA_BRANCH=name or --branch name.
+# Pin a specific release with AURA_VERSION=v1.2.3 or --version v1.2.3.
 
 set -euo pipefail
 
@@ -57,7 +58,83 @@ else
 fi
 
 INSTALL_MODE="${AURA_INSTALL_MODE:-}"
+AURA_BRANCH="${AURA_BRANCH:-}"
 AURA_VERSION="${AURA_VERSION:-}"
+
+usage() {
+    cat <<'EOF'
+Usage: install.sh [options]
+
+Options:
+  --mode source|release   Override install mode detection.
+  --branch <name>         In source mode, switch to and update this git branch.
+  --version <tag>         In release mode, install this release tag (e.g. v1.2.3).
+  -h, --help              Show this help.
+
+Environment equivalents:
+  AURA_INSTALL_MODE=source|release
+  AURA_BRANCH=<name>
+  AURA_VERSION=v1.2.3
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --mode)
+            [ "$#" -ge 2 ] || { echo "error: --mode requires a value" >&2; exit 1; }
+            INSTALL_MODE="$2"
+            shift 2
+            ;;
+        --branch)
+            [ "$#" -ge 2 ] || { echo "error: --branch requires a value" >&2; exit 1; }
+            AURA_BRANCH="$2"
+            shift 2
+            ;;
+        --version|-v)
+            [ "$#" -ge 2 ] || { echo "error: $1 requires a value" >&2; exit 1; }
+            AURA_VERSION="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+case "$INSTALL_MODE" in
+    ""|source|release) ;;
+    *)
+        echo "error: --mode must be 'source' or 'release'" >&2
+        exit 1
+        ;;
+esac
+
+if [ -z "$INSTALL_MODE" ]; then
+    if [ -n "$AURA_BRANCH" ] && [ -n "$AURA_VERSION" ]; then
+        echo "error: --branch is for source installs and --version is for release installs; pass --mode to disambiguate" >&2
+        exit 1
+    elif [ -n "$AURA_BRANCH" ]; then
+        INSTALL_MODE="source"
+    elif [ -n "$AURA_VERSION" ]; then
+        INSTALL_MODE="release"
+    fi
+fi
+
+if [ "$INSTALL_MODE" = "release" ] && [ -n "$AURA_BRANCH" ]; then
+    echo "error: --branch is only supported with --mode source" >&2
+    exit 1
+fi
+
+if [ "$INSTALL_MODE" = "source" ] && [ -n "$AURA_VERSION" ]; then
+    echo "error: --version is only supported with --mode release" >&2
+    exit 1
+fi
 
 if [ -z "$INSTALL_MODE" ]; then
     if [ -n "$ROOT" ] && [ -f "$ROOT/Cargo.toml" ] && command -v cargo >/dev/null 2>&1; then
@@ -94,6 +171,33 @@ verify_checksum() {
     fi
 }
 
+prepare_source_branch() {
+    [ -n "$AURA_BRANCH" ] || return 0
+    [ -n "$ROOT" ] && [ -d "$ROOT/.git" ] || {
+        echo "error: --branch requires source mode from a git checkout" >&2
+        exit 1
+    }
+    command -v git >/dev/null 2>&1 || {
+        echo "error: git not found — required by --branch" >&2
+        exit 1
+    }
+
+    echo "▸ Switching source checkout to ${AURA_BRANCH}…"
+    git -C "$ROOT" fetch --prune origin "$AURA_BRANCH" >/dev/null 2>&1 || true
+    if git -C "$ROOT" rev-parse --verify --quiet "$AURA_BRANCH" >/dev/null; then
+        git -C "$ROOT" switch "$AURA_BRANCH"
+    elif git -C "$ROOT" rev-parse --verify --quiet "origin/$AURA_BRANCH" >/dev/null; then
+        git -C "$ROOT" switch --track "origin/$AURA_BRANCH"
+    else
+        echo "error: branch '$AURA_BRANCH' was not found locally or on origin" >&2
+        exit 1
+    fi
+
+    if git -C "$ROOT" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' >/dev/null 2>&1; then
+        git -C "$ROOT" pull --ff-only
+    fi
+}
+
 # ── Stage binaries + launcher assets ─────────────────────────────────────────
 #
 # After this block STAGING_DIR holds the binaries (and Aura.app on macOS), and
@@ -104,6 +208,8 @@ if [ "$INSTALL_MODE" = "source" ]; then
         echo "error: cargo not found. Install Rust from https://rustup.rs" >&2
         exit 1
     }
+
+    prepare_source_branch
 
     echo "▸ Building Aura (release)…"
     (cd "$ROOT" && cargo build --release --workspace)

--- a/justfile
+++ b/justfile
@@ -45,7 +45,12 @@ fix:
 
 # ── Install ───────────────────────────────────────────────────────────────────
 
-# Install Aura — tray-indicator-style (autostart by default). Dispatches
+# Install Aura — tray-indicator-style (autostart by default). Optional
+# params pass through to the installer:
+#   just install --branch main
+#   just install --version v1.2.3 --mode release
+#
+# Dispatches
 # by host:
 # Linux:   binaries → ~/.local/bin + systemd user unit (enable --now) +
 #          XDG .desktop entry (app-menu discoverability)
@@ -53,11 +58,12 @@ fix:
 #          LaunchAgent (loaded now + at every login)
 # Windows: use `just install-windows` from PowerShell — installs aura.exe
 #          + a Startup-folder shortcut (autostart) + a Start Menu shortcut.
-install:
-    ./install.sh
+# Pass installer flags after the recipe name.
+install *args:
+    ./install.sh {{args}}
 
-install-windows:
-    powershell -ExecutionPolicy Bypass -File scripts/install.ps1
+install-windows *args:
+    powershell -ExecutionPolicy Bypass -File scripts/install.ps1 {{args}}
 
 # Install only the RTK plugin binary (useful when iterating on plugin code)
 install-plugin-rtk: build-rtk
@@ -72,9 +78,14 @@ install-plugin-rtk: build-rtk
 # new install. Then `install` lays down the fresh binary at the same path the
 # systemd unit / launchd agent points at, so the tray icon comes back bound
 # to the updated binary.
-update: uninstall install
+# Reinstall Aura, forwarding installer flags to the install step.
+update *args:
+    just uninstall
+    just install {{args}}
 
-update-windows: uninstall-windows install-windows
+update-windows *args:
+    just uninstall-windows
+    just install-windows {{args}}
 
 # ── Uninstall ─────────────────────────────────────────────────────────────────
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -10,8 +10,9 @@
                    release zip for the host, verify its checksum, install.
 
     Auto-detects the mode (source when run from a checkout with cargo on
-    PATH, release otherwise). Override with $env:AURA_INSTALL_MODE.
-    Pin a version with $env:AURA_VERSION = 'v1.2.3'.
+    PATH, release otherwise). Override with -Mode or $env:AURA_INSTALL_MODE.
+    Build a source checkout from a branch with -Branch or $env:AURA_BRANCH.
+    Pin a version with -Version or $env:AURA_VERSION = 'v1.2.3'.
 
     Source mode automatically installs missing build prerequisites via winget:
       - Visual Studio 2022 Build Tools (MSVC linker + headers)
@@ -32,6 +33,14 @@
     Keep in sync with install.sh.
     ASCII-only source: avoids PowerShell 5.1 UTF-8-without-BOM parse errors.
 #>
+
+param(
+    [string]$Mode,
+
+    [string]$Branch,
+
+    [string]$Version
+)
 
 $ErrorActionPreference = 'Stop'
 
@@ -68,7 +77,27 @@ if ($ScriptPath) {
     $RepoRoot  = $null
 }
 
-$Mode = $env:AURA_INSTALL_MODE
+if (-not $Mode) { $Mode = $env:AURA_INSTALL_MODE }
+if (-not $Branch) { $Branch = $env:AURA_BRANCH }
+if (-not $Version) { $Version = $env:AURA_VERSION }
+if ($Mode -and $Mode -notin @('source', 'release')) {
+    throw "-Mode must be 'source' or 'release'"
+}
+if (-not $Mode) {
+    if ($Branch -and $Version) {
+        throw "-Branch is for source installs and -Version is for release installs; pass -Mode to disambiguate"
+    } elseif ($Branch) {
+        $Mode = 'source'
+    } elseif ($Version) {
+        $Mode = 'release'
+    }
+}
+if ($Mode -eq 'release' -and $Branch) {
+    throw "-Branch is only supported with -Mode source"
+}
+if ($Mode -eq 'source' -and $Version) {
+    throw "-Version is only supported with -Mode release"
+}
 if (-not $Mode) {
     if ($RepoRoot -and (Test-Path (Join-Path $RepoRoot 'Cargo.toml')) -and (Get-Command cargo -ErrorAction SilentlyContinue)) {
         $Mode = 'source'
@@ -120,6 +149,42 @@ function Test-Sha256 {
     $actual   = (Get-FileHash -Algorithm SHA256 $zipPath).Hash.ToLower()
     if ($expected -ne $actual) {
         throw "SHA256 mismatch for $Asset.zip (expected $expected, got $actual)"
+    }
+}
+
+function Set-SourceBranch {
+    if (-not $Branch) { return }
+    if (-not $RepoRoot -or -not (Test-Path (Join-Path $RepoRoot '.git'))) {
+        throw "-Branch requires source mode from a git checkout"
+    }
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        throw "git not found; required by -Branch"
+    }
+
+    Write-Host "> Switching source checkout to $Branch..."
+    Push-Location $RepoRoot
+    try {
+        & git fetch --prune origin $Branch 2>$null
+        $localExists = (& git rev-parse --verify --quiet $Branch) -ne $null
+        if ($localExists) {
+            & git switch $Branch
+        } else {
+            $remoteExists = (& git rev-parse --verify --quiet "origin/$Branch") -ne $null
+            if ($remoteExists) {
+                & git switch --track "origin/$Branch"
+            } else {
+                throw "branch '$Branch' was not found locally or on origin"
+            }
+        }
+        if ($LASTEXITCODE -ne 0) { throw "git switch failed" }
+
+        & git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' *> $null
+        if ($LASTEXITCODE -eq 0) {
+            & git pull --ff-only
+            if ($LASTEXITCODE -ne 0) { throw "git pull --ff-only failed" }
+        }
+    } finally {
+        Pop-Location
     }
 }
 
@@ -288,6 +353,7 @@ if ($Mode -eq 'source') {
     }
 
     Invoke-BuildPrerequisites
+    Set-SourceBranch
 
     Write-Host "> Building Aura (release)..."
     Push-Location $RepoRoot
@@ -300,7 +366,6 @@ if ($Mode -eq 'source') {
     $StageDir = Join-Path $RepoRoot 'target\release'
 }
 else {
-    $Version = $env:AURA_VERSION
     if (-not $Version) {
         Write-Host "> Resolving latest release..."
         $Version = Resolve-LatestVersion

--- a/vendor/gpui/src/platform/linux/x11/window.rs
+++ b/vendor/gpui/src/platform/linux/x11/window.rs
@@ -313,7 +313,14 @@ impl rwh::HasDisplayHandle for RawWindow {
 
 impl rwh::HasWindowHandle for X11Window {
     fn window_handle(&self) -> Result<rwh::WindowHandle<'_>, rwh::HandleError> {
-        unimplemented!()
+        // Aura patch: expose the XCB window id so callers can reposition the
+        // window via x11rb (GPUI 0.2 has no public move API). Mirrors
+        // `RawWindow::window_handle` above. Upstream left this unimplemented.
+        let Some(non_zero) = NonZeroU32::new(self.0.x_window) else {
+            return Err(rwh::HandleError::Unavailable);
+        };
+        let handle = rwh::XcbWindowHandle::new(non_zero);
+        Ok(unsafe { rwh::WindowHandle::borrow_raw(handle.into()) })
     }
 }
 impl rwh::HasDisplayHandle for X11Window {


### PR DESCRIPTION
- **refactor(ui): centralize modal placement into a single source of truth**
- **fix(ui): anchor modal by config and reposition on X11 to stop window drift**
- **feat(install): accept --branch/--version/--mode flags on both installers**
- **docs(troubleshooting): KDE Morphing Popups stretches the modal on resize**
- **fix(ui): order bottom-anchor resize+move by direction to avoid off-screen excursion**
