### PR TITLE
feat(cli): self-documenting config surface (describe/get/set/wizard/init/document)

### DIFF
--- a/crates/aura-core/src/config.rs
+++ b/crates/aura-core/src/config.rs
@@ -241,7 +241,7 @@ impl AppConfig {
             fs::create_dir_all(parent)
                 .with_context(|| format!("create config dir {}", parent.display()))?;
         }
-        let toml = toml::to_string_pretty(self).context("serialize config")?;
+        let toml = crate::config_schema::render_commented(self).context("serialize config")?;
         fs::write(path, toml).with_context(|| format!("write config to {}", path.display()))
     }
 
@@ -254,7 +254,8 @@ impl AppConfig {
                 fs::create_dir_all(parent)
                     .with_context(|| format!("create config dir {}", parent.display()))?;
             }
-            let toml = toml::to_string_pretty(&cfg).context("serialize default config")?;
+            let toml =
+                crate::config_schema::render_commented(&cfg).context("serialize default config")?;
             fs::write(path, toml)
                 .with_context(|| format!("write default config to {}", path.display()))?;
             return Ok(cfg);
@@ -403,7 +404,7 @@ impl AppConfig {
             fs::create_dir_all(parent)
                 .with_context(|| format!("create config dir {}", parent.display()))?;
         }
-        let toml = toml::to_string_pretty(&config).context("serialize config")?;
+        let toml = crate::config_schema::render_commented(&config).context("serialize config")?;
         fs::write(path, toml).with_context(|| format!("write config to {}", path.display()))?;
 
         Ok(SetupReport {

--- a/crates/aura-core/src/config_schema.rs
+++ b/crates/aura-core/src/config_schema.rs
@@ -1,0 +1,716 @@
+//! Field registry for [`AppConfig`] — the single source of truth that powers
+//! the self-documenting config surfaces:
+//!
+//! - `aura config describe` (and `--format json`)
+//! - the commented `config.toml` template ([`render_commented`])
+//! - `aura config get` / `set` ([`get_value`] / [`set_value`])
+//! - `aura config wizard`
+//!
+//! Every settable scalar field under `[display]` / `[update]` has a
+//! [`FieldDescriptor`] here. A unit test (`registry_covers_every_field`)
+//! serializes a default config and asserts each leaf key is described, so
+//! adding a struct field without documenting it breaks the build.
+//!
+//! The repeatable `[[agents]]` / `[[plugins]]` tables are *documented* via
+//! [`agent_fields`] / [`plugin_fields`] but are not get/set targets — they're
+//! managed with `aura agents`, `aura plugin`, or `config edit`.
+
+use anyhow::{Context, Result};
+
+use crate::config::AppConfig;
+
+// ── Descriptors ────────────────────────────────────────────────────────────────
+
+/// One settable scalar config field.
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub struct FieldDescriptor {
+    /// Dotted key path, e.g. `"display.anchor"`.
+    pub key: &'static str,
+    /// Human type label: `string`, `string?`, `string[]`, `bool`, `u32?`.
+    pub type_label: &'static str,
+    /// Constrained value set, or `&[]` when free-form.
+    pub allowed: &'static [&'static str],
+    /// Default value, rendered for `describe`.
+    pub default: &'static str,
+    /// One-line summary; also used as the comment above the key in the template.
+    pub summary: &'static str,
+    /// Full description (lifted from the doc comments in `config.rs`).
+    pub description: &'static str,
+    /// Example value, used by the template for optional/unset fields.
+    pub example: &'static str,
+}
+
+/// One field of a repeatable `[[agents]]` / `[[plugins]]` table — documentation
+/// only (these are not get/set targets).
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub struct SectionField {
+    /// Bare field name, e.g. `"config_path"`.
+    pub key: &'static str,
+    pub type_label: &'static str,
+    pub allowed: &'static [&'static str],
+    pub summary: &'static str,
+}
+
+/// All settable scalar fields, in template-emission order (`display.*` then
+/// `update.*`).
+pub fn fields() -> &'static [FieldDescriptor] {
+    &[
+        FieldDescriptor {
+            key: "display.default_period",
+            type_label: "string",
+            allowed: &["all", "7d", "30d"],
+            default: "all",
+            summary: "Which usage period tab is selected on open.",
+            description: "Which period to show by default: \"all\", \"7d\" (last 7 days), or \
+                \"30d\" (last 30 days). Unrecognised values fall back to \"all\".",
+            example: "all",
+        },
+        FieldDescriptor {
+            key: "display.anchor",
+            type_label: "string",
+            allowed: &["none", "bottom", "top"],
+            default: "\"none\" (macOS/Linux), \"bottom\" (Windows)",
+            summary: "How the modal anchors as it auto-fits its content height.",
+            description: "How the modal anchors as it auto-fits its content height. \
+                \"none\": open at the platform's natural tray corner and grow downward; \
+                never reposition after a resize (safe on Wayland, where the compositor \
+                owns placement). \"bottom\": pin the bottom edge above a bottom taskbar so \
+                it grows upward (the tray-popup feel). \"top\": pin the top edge below a top \
+                panel / menu bar and grow downward. Default is per-OS: \"bottom\" on Windows, \
+                \"none\" on macOS and Linux. Unrecognised values (incl. the legacy \"auto\") \
+                fall back to the per-OS default.",
+            example: "none",
+        },
+        FieldDescriptor {
+            key: "display.plugin_order",
+            type_label: "string[]",
+            allowed: &[],
+            default: "[] (config-then-discovered order)",
+            summary: "Display order for plugin pills (comma-separated names on `set`).",
+            description: "Display order for plugin pills. Plugins whose display name appears \
+                here render in the listed order; anything not named keeps its natural order \
+                (config-then-discovered-alphabetical) and appends after the explicitly-ordered \
+                prefix. Match is case-insensitive. On `set`, pass a comma-separated list.",
+            example: "RTK Gains, Hello",
+        },
+        FieldDescriptor {
+            key: "display.show_in_app_switcher",
+            type_label: "bool",
+            allowed: &["true", "false"],
+            default: "false",
+            summary: "Show the modal in Alt+Tab / Cmd+Tab / dock surfaces.",
+            description: "Whether the modal appears in the OS's \"where are my windows\" \
+                surfaces — Cmd+Tab + Dock on macOS, Alt+Tab + taskbar on Windows, panel + \
+                window switcher on Linux. Default false so Aura behaves like a true \
+                tray-indicator. Set true if you want to alt-tab to the modal. On macOS this \
+                also drives the process-wide NSApplication activation policy.",
+            example: "false",
+        },
+        FieldDescriptor {
+            key: "display.dismiss_on_focus_loss",
+            type_label: "bool",
+            allowed: &["true", "false"],
+            default: "true",
+            summary: "Auto-close the modal when it loses focus.",
+            description: "Auto-close the modal when it loses focus (click outside, switch \
+                app). Default true — matches typical menu-bar / tray-popup behaviour. Set \
+                false if you'd rather the modal stay open until you click the tray icon again \
+                (useful when copy-pasting from the modal into another window).",
+            example: "true",
+        },
+        FieldDescriptor {
+            key: "display.window_chrome",
+            type_label: "bool",
+            allowed: &["true", "false"],
+            default: "false",
+            summary: "Show native window chrome (title bar + drag-to-resize).",
+            description: "Show the OS-native window chrome (title bar + minimize / maximize / \
+                close buttons) and let the user resize the modal by dragging its edges. \
+                Default false: Aura behaves like a tray popup with a fixed width that \
+                auto-fits its content vertically. Turning this on also enables resizing and \
+                suppresses the content-fit auto-resize (which would otherwise fight the drag).",
+            example: "false",
+        },
+        FieldDescriptor {
+            key: "display.max_height",
+            type_label: "u32?",
+            allowed: &[],
+            default: "unset (only the screen work-area cap applies)",
+            summary: "Upper bound, in logical pixels, on the modal's auto-fit height.",
+            description: "Optional upper bound (in logical pixels) on the modal's auto-fit \
+                height. The content-fit callback already caps growth at the screen's available \
+                work area; this lets you impose a tighter ceiling so the modal never grows \
+                past, say, 500 px even on a tall display. Unset means \"only the work-area cap \
+                applies\". Ignored when window_chrome is true (auto-fit is off then).",
+            example: "500",
+        },
+        FieldDescriptor {
+            key: "display.goblin_mode",
+            type_label: "bool",
+            allowed: &["true", "false"],
+            default: "false",
+            summary: "Swap UI copy for the aggressive \"Goblin Mode\" variant.",
+            description: "Swap the modal's user-facing copy for an aggressive / unhinged \
+                variant (\"Goblin Mode\"). Default false. Toggling reloads on the next refresh \
+                — no restart. See docs/goblin-mode.md.",
+            example: "false",
+        },
+        FieldDescriptor {
+            key: "update.dismissed_version",
+            type_label: "string?",
+            allowed: &[],
+            default: "unset (never dismissed)",
+            summary: "Last release version dismissed via the update button's \u{00d7}.",
+            description: "The last release version the user dismissed via the \"x\" on the \
+                update button. Stored as the bare semver string (\"0.1.18\"). Any newer release \
+                re-shows the button. Unset means \"never dismissed\".",
+            example: "0.1.18",
+        },
+        FieldDescriptor {
+            key: "update.dismiss_all",
+            type_label: "bool",
+            allowed: &["true", "false"],
+            default: "false",
+            summary: "Master mute: never show the update button or check for updates.",
+            description: "Master switch. When true, the update button is never rendered and \
+                the background check is skipped entirely (so no GitHub request fires). Off by \
+                default.",
+            example: "false",
+        },
+    ]
+}
+
+/// Fields of a `[[agents]]` block (documentation only).
+pub fn agent_fields() -> &'static [SectionField] {
+    &[
+        SectionField {
+            key: "name",
+            type_label: "string",
+            allowed: &[],
+            summary: "Display name for this agent profile.",
+        },
+        SectionField {
+            key: "kind",
+            type_label: "string",
+            allowed: &["claude-code", "codex", "gemini"],
+            summary: "Which agent this profile reads.",
+        },
+        SectionField {
+            key: "config_path",
+            type_label: "string?",
+            allowed: &[],
+            summary: "Agent config dir; defaults to ~/.claude, ~/.codex, ~/.gemini per kind.",
+        },
+        SectionField {
+            key: "color",
+            type_label: "string?",
+            allowed: &[],
+            summary: "Accent color override, hex like #rrggbb or #rgb.",
+        },
+    ]
+}
+
+/// Fields of a `[[plugins]]` block (documentation only).
+pub fn plugin_fields() -> &'static [SectionField] {
+    &[
+        SectionField {
+            key: "name",
+            type_label: "string",
+            allowed: &[],
+            summary: "Display name for the plugin pill.",
+        },
+        SectionField {
+            key: "command",
+            type_label: "string",
+            allowed: &[],
+            summary: "Binary name on $PATH or absolute path.",
+        },
+        SectionField {
+            key: "color",
+            type_label: "string?",
+            allowed: &[],
+            summary: "Accent color override, hex like #rrggbb or #rgb.",
+        },
+        SectionField {
+            key: "icon",
+            type_label: "string?",
+            allowed: &[],
+            summary: "SVG icon: embedded asset name, absolute path, or ~/ path.",
+        },
+    ]
+}
+
+/// Look up a descriptor by its dotted key.
+pub fn field(key: &str) -> Option<&'static FieldDescriptor> {
+    fields().iter().find(|f| f.key == key)
+}
+
+// ── Errors ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub enum SchemaError {
+    UnknownKey {
+        key: String,
+        suggestion: Option<&'static str>,
+    },
+    InvalidValue {
+        key: String,
+        value: String,
+        allowed: Vec<&'static str>,
+    },
+    InvalidType {
+        key: String,
+        expected: &'static str,
+        value: String,
+    },
+}
+
+impl std::fmt::Display for SchemaError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SchemaError::UnknownKey { key, suggestion } => {
+                write!(f, "unknown config key `{key}`")?;
+                if let Some(s) = suggestion {
+                    write!(f, " (did you mean `{s}`?)")?;
+                }
+                write!(
+                    f,
+                    "\n  run `aura config describe` to list settable keys; \
+                     agents and plugins are managed via `aura agents` / `aura plugin` / `config edit`"
+                )
+            }
+            SchemaError::InvalidValue {
+                key,
+                value,
+                allowed,
+            } => write!(
+                f,
+                "invalid value `{value}` for `{key}`\n  allowed: {}",
+                allowed.join(" | ")
+            ),
+            SchemaError::InvalidType {
+                key,
+                expected,
+                value,
+            } => write!(f, "invalid value `{value}` for `{key}`: expected {expected}"),
+        }
+    }
+}
+
+impl std::error::Error for SchemaError {}
+
+fn unknown_key(key: &str) -> SchemaError {
+    let leaf = key.rsplit('.').next().unwrap_or(key);
+    // Suggest the nearest key: exact, or one leaf is a substring of the other
+    // (catches typos like `anchorr` → `anchor` and bare leaves like `anchor`).
+    let suggestion = fields().iter().map(|f| f.key).find(|k| {
+        let kl = k.rsplit('.').next().unwrap_or(k);
+        *k == key || kl == leaf || kl.contains(leaf) || leaf.contains(kl)
+    });
+    SchemaError::UnknownKey {
+        key: key.to_string(),
+        suggestion,
+    }
+}
+
+// ── Read / write a single field ────────────────────────────────────────────────
+
+/// Read a field's current value as a human-readable string. Optional fields
+/// that are unset render as `(unset)`.
+pub fn get_value(cfg: &AppConfig, key: &str) -> Result<String, SchemaError> {
+    let v = match key {
+        "display.default_period" => cfg.display.default_period.clone(),
+        "display.anchor" => cfg.display.anchor.clone(),
+        "display.plugin_order" => cfg.display.plugin_order.join(", "),
+        "display.show_in_app_switcher" => cfg.display.show_in_app_switcher.to_string(),
+        "display.dismiss_on_focus_loss" => cfg.display.dismiss_on_focus_loss.to_string(),
+        "display.window_chrome" => cfg.display.window_chrome.to_string(),
+        "display.max_height" => cfg
+            .display
+            .max_height
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| "(unset)".to_string()),
+        "display.goblin_mode" => cfg.display.goblin_mode.to_string(),
+        "update.dismissed_version" => cfg
+            .update
+            .dismissed_version
+            .clone()
+            .unwrap_or_else(|| "(unset)".to_string()),
+        "update.dismiss_all" => cfg.update.dismiss_all.to_string(),
+        _ => return Err(unknown_key(key)),
+    };
+    Ok(v)
+}
+
+/// Parse `raw` against the field's type and assign it. Validates enums against
+/// `allowed`; clears optional fields when `raw` is empty / `none` / `null`.
+pub fn set_value(cfg: &mut AppConfig, key: &str, raw: &str) -> Result<(), SchemaError> {
+    let raw = raw.trim();
+    match key {
+        "display.default_period" => {
+            cfg.display.default_period = parse_enum(key, raw, &["all", "7d", "30d"])?
+        }
+        "display.anchor" => {
+            cfg.display.anchor = parse_enum(key, raw, &["none", "bottom", "top"])?
+        }
+        "display.plugin_order" => cfg.display.plugin_order = parse_list(raw),
+        "display.show_in_app_switcher" => cfg.display.show_in_app_switcher = parse_bool(key, raw)?,
+        "display.dismiss_on_focus_loss" => cfg.display.dismiss_on_focus_loss = parse_bool(key, raw)?,
+        "display.window_chrome" => cfg.display.window_chrome = parse_bool(key, raw)?,
+        "display.max_height" => cfg.display.max_height = parse_opt_u32(key, raw)?,
+        "display.goblin_mode" => cfg.display.goblin_mode = parse_bool(key, raw)?,
+        "update.dismissed_version" => cfg.update.dismissed_version = parse_opt_string(raw),
+        "update.dismiss_all" => cfg.update.dismiss_all = parse_bool(key, raw)?,
+        _ => return Err(unknown_key(key)),
+    }
+    Ok(())
+}
+
+fn parse_enum(key: &str, raw: &str, allowed: &'static [&'static str]) -> Result<String, SchemaError> {
+    match allowed.iter().find(|a| a.eq_ignore_ascii_case(raw)) {
+        Some(canonical) => Ok((*canonical).to_string()),
+        None => Err(SchemaError::InvalidValue {
+            key: key.to_string(),
+            value: raw.to_string(),
+            allowed: allowed.to_vec(),
+        }),
+    }
+}
+
+fn parse_bool(key: &str, raw: &str) -> Result<bool, SchemaError> {
+    match raw.to_ascii_lowercase().as_str() {
+        "true" | "yes" | "on" | "1" => Ok(true),
+        "false" | "no" | "off" | "0" => Ok(false),
+        _ => Err(SchemaError::InvalidType {
+            key: key.to_string(),
+            expected: "a boolean (true/false)",
+            value: raw.to_string(),
+        }),
+    }
+}
+
+fn is_clear(raw: &str) -> bool {
+    matches!(raw.to_ascii_lowercase().as_str(), "" | "none" | "null" | "unset")
+}
+
+fn parse_opt_u32(key: &str, raw: &str) -> Result<Option<u32>, SchemaError> {
+    if is_clear(raw) {
+        return Ok(None);
+    }
+    raw.parse::<u32>().map(Some).map_err(|_| SchemaError::InvalidType {
+        key: key.to_string(),
+        expected: "a non-negative integer or `none`",
+        value: raw.to_string(),
+    })
+}
+
+fn parse_opt_string(raw: &str) -> Option<String> {
+    if is_clear(raw) {
+        None
+    } else {
+        Some(raw.to_string())
+    }
+}
+
+fn parse_list(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+// ── Commented template renderer ─────────────────────────────────────────────────
+
+/// Render `cfg` as a `config.toml` whose `[display]` / `[update]` keys each
+/// carry a `#` comment, preceded by section docs for `[[agents]]` /
+/// `[[plugins]]`. Round-trips: parsing the output yields `cfg` again.
+pub fn render_commented(cfg: &AppConfig) -> Result<String> {
+    let mut out = String::new();
+    out.push_str("# Aura configuration.\n");
+    out.push_str("# Run `aura config describe` for full field docs, or\n");
+    out.push_str("# `aura config set <key> <value>` to change a value from the CLI.\n\n");
+
+    push_section_docs(&mut out, "agents", agent_fields());
+    for agent in &cfg.agents {
+        out.push_str("[[agents]]\n");
+        out.push_str(&toml::to_string(agent).context("serialize agent entry")?);
+        out.push('\n');
+    }
+
+    push_section_docs(&mut out, "plugins", plugin_fields());
+    for plugin in &cfg.plugins {
+        out.push_str("[[plugins]]\n");
+        out.push_str(&toml::to_string(plugin).context("serialize plugin entry")?);
+        out.push('\n');
+    }
+
+    push_scalar_table(&mut out, cfg, "display");
+    out.push('\n');
+    push_scalar_table(&mut out, cfg, "update");
+
+    Ok(out)
+}
+
+fn push_section_docs(out: &mut String, name: &str, fields: &[SectionField]) {
+    out.push_str(&format!(
+        "# ── [[{name}]] ── repeatable; one block per {name} entry.\n"
+    ));
+    for f in fields {
+        out.push_str(&format!(
+            "#   {} ({}){} — {}\n",
+            f.key,
+            f.type_label,
+            allowed_suffix(f.allowed),
+            f.summary
+        ));
+    }
+    out.push('\n');
+}
+
+fn push_scalar_table(out: &mut String, cfg: &AppConfig, section: &str) {
+    out.push_str(&format!("[{section}]\n"));
+    let prefix = format!("{section}.");
+    for f in fields().iter().filter(|f| f.key.starts_with(&prefix)) {
+        let leaf = &f.key[prefix.len()..];
+        for line in wrap_text(f.summary, 72) {
+            out.push_str("# ");
+            out.push_str(&line);
+            out.push('\n');
+        }
+        match toml_rhs(cfg, f.key) {
+            Some(rhs) => out.push_str(&format!("{leaf} = {rhs}\n")),
+            // Optional + unset: emit a commented example so the key is discoverable.
+            None => out.push_str(&format!("# {leaf} = {}\n", example_rhs(f))),
+        }
+    }
+}
+
+/// TOML-formatted right-hand side for a field, or `None` when an optional field
+/// is unset (so the renderer emits a commented example instead).
+fn toml_rhs(cfg: &AppConfig, key: &str) -> Option<String> {
+    Some(match key {
+        "display.default_period" => quote(&cfg.display.default_period),
+        "display.anchor" => quote(&cfg.display.anchor),
+        "display.plugin_order" => str_array(&cfg.display.plugin_order),
+        "display.show_in_app_switcher" => cfg.display.show_in_app_switcher.to_string(),
+        "display.dismiss_on_focus_loss" => cfg.display.dismiss_on_focus_loss.to_string(),
+        "display.window_chrome" => cfg.display.window_chrome.to_string(),
+        "display.max_height" => return cfg.display.max_height.map(|n| n.to_string()),
+        "display.goblin_mode" => cfg.display.goblin_mode.to_string(),
+        "update.dismissed_version" => return cfg.update.dismissed_version.as_deref().map(quote),
+        "update.dismiss_all" => cfg.update.dismiss_all.to_string(),
+        _ => return None,
+    })
+}
+
+fn example_rhs(f: &FieldDescriptor) -> String {
+    match f.type_label {
+        "string" | "string?" => quote(f.example),
+        _ => f.example.to_string(),
+    }
+}
+
+fn allowed_suffix(allowed: &[&str]) -> String {
+    if allowed.is_empty() {
+        String::new()
+    } else {
+        format!(" [{}]", allowed.join(" | "))
+    }
+}
+
+/// Quote a string as a TOML basic string (with proper escaping).
+fn quote(s: &str) -> String {
+    toml::Value::String(s.to_string()).to_string()
+}
+
+fn str_array(items: &[String]) -> String {
+    let inner = items.iter().map(|s| quote(s)).collect::<Vec<_>>().join(", ");
+    format!("[{inner}]")
+}
+
+fn wrap_text(text: &str, width: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut cur = String::new();
+    for word in text.split_whitespace() {
+        if !cur.is_empty() && cur.len() + 1 + word.len() > width {
+            lines.push(std::mem::take(&mut cur));
+        }
+        if !cur.is_empty() {
+            cur.push(' ');
+        }
+        cur.push_str(word);
+    }
+    if !cur.is_empty() {
+        lines.push(cur);
+    }
+    if lines.is_empty() {
+        lines.push(String::new());
+    }
+    lines
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{AgentConfig, AgentKind, DisplayConfig, PluginConfig, UpdateConfig};
+
+    /// Walk a serialized default config and assert every leaf key under
+    /// `[display]` / `[update]` has a `FieldDescriptor`. Fails if a struct
+    /// field is added without a descriptor — the anti-drift guard.
+    /// A config with every optional field populated, so `None`-valued fields
+    /// (which serde omits from TOML) still appear when checking coverage.
+    fn fully_populated() -> AppConfig {
+        let mut cfg = AppConfig::default_config();
+        cfg.display.max_height = Some(500);
+        cfg.update.dismissed_version = Some("0.0.0".to_string());
+        cfg
+    }
+
+    #[test]
+    fn registry_covers_every_field() {
+        let cfg = fully_populated();
+        let value = toml::Value::try_from(&cfg).unwrap();
+        let table = value.as_table().unwrap();
+
+        for section in ["display", "update"] {
+            let sub = table
+                .get(section)
+                .and_then(|v| v.as_table())
+                .unwrap_or_else(|| panic!("section [{section}] missing from serialized config"));
+            for leaf in sub.keys() {
+                let key = format!("{section}.{leaf}");
+                assert!(
+                    field(&key).is_some(),
+                    "config key `{key}` has no FieldDescriptor in config_schema::fields()"
+                );
+            }
+        }
+
+        // ...and no descriptor names a key that doesn't exist on the struct.
+        for f in fields() {
+            let (section, leaf) = f.key.split_once('.').unwrap();
+            let present = table
+                .get(section)
+                .and_then(|v| v.as_table())
+                .map(|t| t.contains_key(leaf))
+                .unwrap_or(false);
+            assert!(present, "descriptor `{}` names a non-existent field", f.key);
+        }
+    }
+
+    #[test]
+    fn get_and_set_round_trip_every_descriptor() {
+        for f in fields() {
+            let mut cfg = AppConfig::default_config();
+            // get_value must handle the key.
+            get_value(&cfg, f.key).unwrap_or_else(|e| panic!("get `{}`: {e}", f.key));
+            // set_value(example) then get_value should reflect the example.
+            set_value(&mut cfg, f.key, f.example)
+                .unwrap_or_else(|e| panic!("set `{}` = `{}`: {e}", f.key, f.example));
+            let got = get_value(&cfg, f.key).unwrap();
+            // For list/optional types the rendered form differs from the raw
+            // example, so just assert it's non-empty and not the unset marker.
+            assert_ne!(got, "(unset)", "`{}` still unset after set", f.key);
+        }
+    }
+
+    #[test]
+    fn set_value_validates() {
+        let mut cfg = AppConfig::default_config();
+
+        // Bad enum value lists the allowed set.
+        let err = set_value(&mut cfg, "display.anchor", "sideways").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("none | bottom | top"), "{msg}");
+
+        // Bad bool.
+        let err = set_value(&mut cfg, "display.goblin_mode", "maybe").unwrap_err();
+        assert!(err.to_string().contains("boolean"));
+
+        // Bad int.
+        assert!(set_value(&mut cfg, "display.max_height", "tall").is_err());
+
+        // Unknown key suggests a real one.
+        let err = set_value(&mut cfg, "display.anchorr", "top").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("unknown config key"), "{msg}");
+        assert!(msg.contains("did you mean"), "{msg}");
+
+        // Clearing an optional.
+        cfg.display.max_height = Some(400);
+        set_value(&mut cfg, "display.max_height", "none").unwrap();
+        assert_eq!(cfg.display.max_height, None);
+
+        // Enum is case-insensitive and canonicalized.
+        set_value(&mut cfg, "display.anchor", "TOP").unwrap();
+        assert_eq!(cfg.display.anchor, "top");
+
+        // List parsing.
+        set_value(&mut cfg, "display.plugin_order", "A, B ,C").unwrap();
+        assert_eq!(cfg.display.plugin_order, vec!["A", "B", "C"]);
+    }
+
+    fn assert_round_trips(cfg: &AppConfig) {
+        let rendered = render_commented(cfg).unwrap();
+        let parsed: AppConfig = toml::from_str(&rendered)
+            .unwrap_or_else(|e| panic!("re-parse rendered config: {e}\n---\n{rendered}"));
+
+        assert_eq!(parsed.agents.len(), cfg.agents.len());
+        for (a, b) in parsed.agents.iter().zip(&cfg.agents) {
+            assert_eq!(a.name, b.name);
+            assert_eq!(a.kind, b.kind);
+            assert_eq!(a.config_path, b.config_path);
+            assert_eq!(a.color, b.color);
+        }
+        assert_eq!(parsed.plugins.len(), cfg.plugins.len());
+        for (a, b) in parsed.plugins.iter().zip(&cfg.plugins) {
+            assert_eq!(a.name, b.name);
+            assert_eq!(a.command, b.command);
+            assert_eq!(a.color, b.color);
+            assert_eq!(a.icon, b.icon);
+        }
+        assert_eq!(parsed.display, cfg.display);
+        assert_eq!(parsed.update, cfg.update);
+    }
+
+    #[test]
+    fn render_commented_round_trips_default() {
+        assert_round_trips(&AppConfig::default_config());
+    }
+
+    #[test]
+    fn render_commented_round_trips_populated() {
+        let cfg = AppConfig {
+            agents: vec![AgentConfig {
+                name: "Work Claude".to_string(),
+                kind: AgentKind::ClaudeCode,
+                config_path: Some("~/.claude-work".to_string()),
+                color: Some("#abcdef".to_string()),
+            }],
+            plugins: vec![PluginConfig {
+                name: "RTK Gains".to_string(),
+                command: "aura-plugin-rtk".to_string(),
+                color: Some("#123".to_string()),
+                icon: Some("icons/blocks.svg".to_string()),
+            }],
+            display: DisplayConfig {
+                default_period: "7d".to_string(),
+                anchor: "top".to_string(),
+                plugin_order: vec!["RTK Gains".to_string(), "Hello".to_string()],
+                show_in_app_switcher: true,
+                dismiss_on_focus_loss: false,
+                window_chrome: true,
+                max_height: Some(500),
+                goblin_mode: true,
+            },
+            update: UpdateConfig {
+                dismissed_version: Some("0.1.18".to_string()),
+                dismiss_all: true,
+            },
+        };
+        assert_round_trips(&cfg);
+    }
+}

--- a/crates/aura-core/src/config_schema.rs
+++ b/crates/aura-core/src/config_schema.rs
@@ -292,7 +292,10 @@ impl std::fmt::Display for SchemaError {
                 key,
                 expected,
                 value,
-            } => write!(f, "invalid value `{value}` for `{key}`: expected {expected}"),
+            } => write!(
+                f,
+                "invalid value `{value}` for `{key}`: expected {expected}"
+            ),
         }
     }
 }
@@ -350,12 +353,12 @@ pub fn set_value(cfg: &mut AppConfig, key: &str, raw: &str) -> Result<(), Schema
         "display.default_period" => {
             cfg.display.default_period = parse_enum(key, raw, &["all", "7d", "30d"])?
         }
-        "display.anchor" => {
-            cfg.display.anchor = parse_enum(key, raw, &["none", "bottom", "top"])?
-        }
+        "display.anchor" => cfg.display.anchor = parse_enum(key, raw, &["none", "bottom", "top"])?,
         "display.plugin_order" => cfg.display.plugin_order = parse_list(raw),
         "display.show_in_app_switcher" => cfg.display.show_in_app_switcher = parse_bool(key, raw)?,
-        "display.dismiss_on_focus_loss" => cfg.display.dismiss_on_focus_loss = parse_bool(key, raw)?,
+        "display.dismiss_on_focus_loss" => {
+            cfg.display.dismiss_on_focus_loss = parse_bool(key, raw)?
+        }
         "display.window_chrome" => cfg.display.window_chrome = parse_bool(key, raw)?,
         "display.max_height" => cfg.display.max_height = parse_opt_u32(key, raw)?,
         "display.goblin_mode" => cfg.display.goblin_mode = parse_bool(key, raw)?,
@@ -366,7 +369,11 @@ pub fn set_value(cfg: &mut AppConfig, key: &str, raw: &str) -> Result<(), Schema
     Ok(())
 }
 
-fn parse_enum(key: &str, raw: &str, allowed: &'static [&'static str]) -> Result<String, SchemaError> {
+fn parse_enum(
+    key: &str,
+    raw: &str,
+    allowed: &'static [&'static str],
+) -> Result<String, SchemaError> {
     match allowed.iter().find(|a| a.eq_ignore_ascii_case(raw)) {
         Some(canonical) => Ok((*canonical).to_string()),
         None => Err(SchemaError::InvalidValue {
@@ -390,18 +397,23 @@ fn parse_bool(key: &str, raw: &str) -> Result<bool, SchemaError> {
 }
 
 fn is_clear(raw: &str) -> bool {
-    matches!(raw.to_ascii_lowercase().as_str(), "" | "none" | "null" | "unset")
+    matches!(
+        raw.to_ascii_lowercase().as_str(),
+        "" | "none" | "null" | "unset"
+    )
 }
 
 fn parse_opt_u32(key: &str, raw: &str) -> Result<Option<u32>, SchemaError> {
     if is_clear(raw) {
         return Ok(None);
     }
-    raw.parse::<u32>().map(Some).map_err(|_| SchemaError::InvalidType {
-        key: key.to_string(),
-        expected: "a non-negative integer or `none`",
-        value: raw.to_string(),
-    })
+    raw.parse::<u32>()
+        .map(Some)
+        .map_err(|_| SchemaError::InvalidType {
+            key: key.to_string(),
+            expected: "a non-negative integer or `none`",
+            value: raw.to_string(),
+        })
 }
 
 fn parse_opt_string(raw: &str) -> Option<String> {
@@ -525,7 +537,11 @@ fn quote(s: &str) -> String {
 }
 
 fn str_array(items: &[String]) -> String {
-    let inner = items.iter().map(|s| quote(s)).collect::<Vec<_>>().join(", ");
+    let inner = items
+        .iter()
+        .map(|s| quote(s))
+        .collect::<Vec<_>>()
+        .join(", ");
     format!("[{inner}]")
 }
 

--- a/crates/aura-core/src/lib.rs
+++ b/crates/aura-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod config_schema;
 pub mod lexicon;
 pub mod plugin;
 pub mod quota;

--- a/crates/aura/src/cli/config.rs
+++ b/crates/aura/src/cli/config.rs
@@ -244,7 +244,10 @@ fn print_section(header: &str, fields: &[SectionField]) {
         } else {
             format!(" [{}]", f.allowed.join(" | "))
         };
-        println!("  {:<14} ({}){allowed} — {}", f.key, f.type_label, f.summary);
+        println!(
+            "  {:<14} ({}){allowed} — {}",
+            f.key, f.type_label, f.summary
+        );
     }
     println!();
 }

--- a/crates/aura/src/cli/config.rs
+++ b/crates/aura/src/cli/config.rs
@@ -3,9 +3,19 @@
 //! Wraps `AppConfig` from `aura-core`. `config setup` is also reachable
 //! via the hidden top-level `setup-config` alias defined in `cli/mod.rs`
 //! so the existing installer scripts keep working.
+//!
+//! Discoverability is driven by the field registry in
+//! `aura_core::config_schema`: `describe` lists/explains every field, `get`
+//! and `set` read/write a single key with validation, and `wizard` walks the
+//! fields interactively. The on-disk `config.toml` is written with `#`
+//! comments above each key (see `config_schema::render_commented`), so the
+//! file itself documents what's available.
+
+use std::io::{self, Write};
 
 use anyhow::{Context, Result};
 use aura_core::config::{AgentStatus, AppConfig};
+use aura_core::config_schema::{self, FieldDescriptor, SectionField};
 use clap::{Args, Subcommand};
 
 use super::format::{print_json, OutputFormat};
@@ -28,6 +38,37 @@ enum ConfigCommand {
         #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
         format: OutputFormat,
     },
+    /// List every config field with its type, default, and docs — or explain
+    /// one field when a key is given (e.g. `display.anchor`).
+    Describe {
+        /// A dotted key to explain in full (omit to list everything).
+        key: Option<String>,
+        #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+        format: OutputFormat,
+    },
+    /// Print the current value of a single key (e.g. `display.anchor`).
+    Get {
+        /// Dotted key, e.g. `display.anchor`.
+        key: String,
+    },
+    /// Set a single key and save (e.g. `set display.anchor top`).
+    Set {
+        /// Dotted key, e.g. `display.anchor`.
+        key: String,
+        /// New value. Use `none` to clear an optional field.
+        value: String,
+    },
+    /// Interactively walk every field, keeping the current value on blank input.
+    Wizard,
+    /// Write a fresh, fully-commented `config.toml`.
+    Init {
+        /// Overwrite an existing config file.
+        #[arg(long)]
+        force: bool,
+    },
+    /// Rewrite the existing `config.toml` in place with inline docs, keeping
+    /// every current value (adds the `#` comments an older config lacks).
+    Document,
     /// Open `config.toml` in `$EDITOR` (creates defaults if missing).
     Edit,
     /// Parse the config file and report errors.
@@ -43,6 +84,12 @@ impl ConfigCli {
                 Ok(())
             }
             ConfigCommand::Show { format } => run_show(format),
+            ConfigCommand::Describe { key, format } => run_describe(key.as_deref(), format),
+            ConfigCommand::Get { key } => run_get(&key),
+            ConfigCommand::Set { key, value } => run_set(&key, &value),
+            ConfigCommand::Wizard => run_wizard(),
+            ConfigCommand::Init { force } => run_init(force),
+            ConfigCommand::Document => run_document(),
             ConfigCommand::Edit => run_edit(),
             ConfigCommand::Validate => run_validate(),
         }
@@ -99,6 +146,210 @@ fn run_show(format: OutputFormat) -> Result<()> {
             Ok(())
         }
     }
+}
+
+// ── describe ────────────────────────────────────────────────────────────────
+
+#[derive(serde::Serialize)]
+struct SchemaJson {
+    fields: Vec<FieldDescriptor>,
+    agents: Vec<SectionField>,
+    plugins: Vec<SectionField>,
+}
+
+fn run_describe(key: Option<&str>, format: OutputFormat) -> Result<()> {
+    match (key, format) {
+        (_, OutputFormat::Json) => {
+            // A single key still emits the whole schema in JSON — callers can
+            // filter with jq; keeping one shape is simpler to consume.
+            print_json(&SchemaJson {
+                fields: config_schema::fields().to_vec(),
+                agents: config_schema::agent_fields().to_vec(),
+                plugins: config_schema::plugin_fields().to_vec(),
+            })
+        }
+        (Some(key), OutputFormat::Text) => describe_one(key),
+        (None, OutputFormat::Text) => {
+            describe_all();
+            Ok(())
+        }
+    }
+}
+
+fn describe_one(key: &str) -> Result<()> {
+    let Some(f) = config_schema::field(key) else {
+        anyhow::bail!(
+            "unknown config key `{key}`. Run `aura config describe` to list settable keys."
+        );
+    };
+    let current = AppConfig::load(&AppConfig::default_path())
+        .ok()
+        .and_then(|cfg| config_schema::get_value(&cfg, key).ok());
+
+    println!("{}  ({})", f.key, f.type_label);
+    if !f.allowed.is_empty() {
+        println!("  allowed: {}", f.allowed.join(" | "));
+    }
+    println!("  default: {}", f.default);
+    if let Some(cur) = current {
+        println!("  current: {cur}");
+    }
+    println!();
+    println!("{}", f.description);
+    Ok(())
+}
+
+fn describe_all() {
+    let current = AppConfig::load(&AppConfig::default_path()).ok();
+
+    println!("Settable keys — `aura config set <key> <value>`:\n");
+    for section in ["display", "update"] {
+        println!("[{section}]");
+        let prefix = format!("{section}.");
+        for f in config_schema::fields()
+            .iter()
+            .filter(|f| f.key.starts_with(&prefix))
+        {
+            let leaf = &f.key[prefix.len()..];
+            let allowed = if f.allowed.is_empty() {
+                String::new()
+            } else {
+                format!("  [{}]", f.allowed.join(" | "))
+            };
+            println!("  {leaf:<22} {}{allowed}", f.type_label);
+            println!("      {}", f.summary);
+            let cur = current
+                .as_ref()
+                .and_then(|c| config_schema::get_value(c, f.key).ok());
+            match cur {
+                Some(cur) => println!("      default: {}   current: {cur}", f.default),
+                None => println!("      default: {}", f.default),
+            }
+        }
+        println!();
+    }
+
+    println!("Repeatable tables — edit via `aura config edit`, `aura agents`, `aura plugin`:\n");
+    print_section("[[agents]]", config_schema::agent_fields());
+    print_section("[[plugins]]", config_schema::plugin_fields());
+
+    println!("Explain one field with `aura config describe <key>` (e.g. display.anchor).");
+}
+
+fn print_section(header: &str, fields: &[SectionField]) {
+    println!("{header}");
+    for f in fields {
+        let allowed = if f.allowed.is_empty() {
+            String::new()
+        } else {
+            format!(" [{}]", f.allowed.join(" | "))
+        };
+        println!("  {:<14} ({}){allowed} — {}", f.key, f.type_label, f.summary);
+    }
+    println!();
+}
+
+// ── get / set / wizard / init ────────────────────────────────────────────────
+
+fn run_get(key: &str) -> Result<()> {
+    let path = AppConfig::default_path();
+    let cfg = AppConfig::load(&path).with_context(|| format!("load {}", path.display()))?;
+    let value = config_schema::get_value(&cfg, key).map_err(anyhow::Error::msg)?;
+    println!("{value}");
+    Ok(())
+}
+
+fn run_set(key: &str, value: &str) -> Result<()> {
+    let path = AppConfig::default_path();
+    let mut cfg = AppConfig::load(&path).with_context(|| format!("load {}", path.display()))?;
+    config_schema::set_value(&mut cfg, key, value).map_err(anyhow::Error::msg)?;
+    cfg.save(&path)
+        .with_context(|| format!("write config to {}", path.display()))?;
+    let stored = config_schema::get_value(&cfg, key).unwrap_or_else(|_| value.to_string());
+    println!("set {key} = {stored}");
+    Ok(())
+}
+
+fn run_wizard() -> Result<()> {
+    let path = AppConfig::default_path();
+    let mut cfg = AppConfig::load(&path).with_context(|| format!("load {}", path.display()))?;
+
+    println!("Editing {}", path.display());
+    println!("Press Enter to keep the current value; type `none` to clear an optional field.\n");
+
+    let stdin = io::stdin();
+    let mut changed = false;
+    for f in config_schema::fields() {
+        let current = config_schema::get_value(&cfg, f.key).unwrap_or_default();
+        let hint = if f.allowed.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", f.allowed.join("/"))
+        };
+        loop {
+            print!("{}{hint} [{current}]: ", f.key);
+            io::stdout().flush().ok();
+            let mut line = String::new();
+            if stdin.read_line(&mut line)? == 0 {
+                // EOF (piped/empty input): stop walking, keep what we have.
+                println!();
+                break;
+            }
+            let input = line.trim();
+            if input.is_empty() {
+                break;
+            }
+            match config_schema::set_value(&mut cfg, f.key, input) {
+                Ok(()) => {
+                    changed = true;
+                    break;
+                }
+                Err(e) => println!("  {e}\n"),
+            }
+        }
+    }
+
+    if changed {
+        cfg.save(&path)
+            .with_context(|| format!("write config to {}", path.display()))?;
+        println!("\nSaved {}", path.display());
+    } else {
+        println!("\nNo changes.");
+    }
+    Ok(())
+}
+
+fn run_init(force: bool) -> Result<()> {
+    let path = AppConfig::default_path();
+    if path.exists() && !force {
+        println!(
+            "{} already exists (pass --force to overwrite).",
+            path.display()
+        );
+        return Ok(());
+    }
+    // `save` serializes through the commented renderer.
+    AppConfig::default_config()
+        .save(&path)
+        .with_context(|| format!("write config to {}", path.display()))?;
+    println!("Wrote {}", path.display());
+    Ok(())
+}
+
+fn run_document() -> Result<()> {
+    let path = AppConfig::default_path();
+    let existed = path.exists();
+    // Load parses the current values; save re-serializes through the commented
+    // renderer, so the rewrite preserves values and (re)applies the inline docs.
+    let cfg = AppConfig::load(&path).with_context(|| format!("load {}", path.display()))?;
+    cfg.save(&path)
+        .with_context(|| format!("write config to {}", path.display()))?;
+    if existed {
+        println!("Rewrote {} with inline documentation.", path.display());
+    } else {
+        println!("Created {} with inline documentation.", path.display());
+    }
+    Ok(())
 }
 
 fn run_edit() -> Result<()> {

--- a/crates/aura/src/cli/mod.rs
+++ b/crates/aura/src/cli/mod.rs
@@ -42,7 +42,8 @@ pub struct Cli {
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
-    /// Manage the on-disk config (`~/.config/aura/config.toml`).
+    /// Manage the on-disk config (`~/.config/aura/config.toml`): describe,
+    /// get/set, wizard, edit (`~/.config/aura/config.toml`).
     Config(config::ConfigCli),
 
     /// Inspect and modify state (`~/.local/share/aura/state.json`).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -59,12 +59,28 @@ If none of those resolve, the command exits with an error suggesting
 ## `aura config`
 
 ```text
-aura config setup       # detect installed agents, write/update config.toml
-aura config path        # print resolved config path
-aura config show        # print loaded config (--format text|json)
-aura config edit        # open in $EDITOR (creates defaults if missing)
-aura config validate    # parse-check
+aura config setup              # detect installed agents, write/update config.toml
+aura config path               # print resolved config path
+aura config show               # print loaded config (--format text|json)
+aura config describe [<key>]   # list every field (type/default/docs), or explain one
+                               #   (--format json emits the full schema)
+aura config get <key>          # print a single field's current value
+aura config set <key> <value>  # validate and set one field (e.g. set display.anchor top)
+aura config wizard             # walk every field interactively; blank keeps current
+aura config init [--force]     # write a fresh, fully-commented config.toml
+aura config document           # rewrite the existing config in place with inline
+                               #   docs, keeping every current value
+aura config edit               # open in $EDITOR (creates defaults if missing)
+aura config validate           # parse-check
 ```
+
+Keys are dotted paths into the `[display]` / `[update]` tables, e.g.
+`display.anchor`, `display.max_height`, `update.dismiss_all`. `set` validates
+the value (rejecting bad enums/booleans and suggesting near-miss keys); pass
+`none` to clear an optional field. The on-disk `config.toml` is written with a
+`#` comment above each key, so the file documents itself. The repeatable
+`[[agents]]` / `[[plugins]]` tables are documented by `describe` but edited via
+`aura config edit`, `aura agents`, or `aura plugin`.
 
 ## `aura state`
 


### PR DESCRIPTION
Config fields were only documented in Rust doc comments users never saw;
the only editing path was a raw config.toml in $EDITOR with no hint at
what fields exist or what values they accept.

Add a single field registry in aura-core (config_schema.rs) as the source
of truth for:
  - `config describe [key]` — list every field (type/default/allowed/docs)
    or explain one; `--format json` emits the full schema
  - `config get`/`set <key> <value>` — validated, editor-free edits with
    helpful errors and near-miss key suggestions
  - `config wizard` — walk fields interactively, blank keeps current
  - `config init [--force]` — write a fresh, fully-commented config.toml
  - `config document` — rewrite an existing config in place with inline
    docs, preserving every value

A test (registry_covers_every_field) serializes a config and asserts each
leaf key has a descriptor, so the docs can't drift from the structs.

Route AppConfig save/load/run_setup writes through render_commented so the
on-disk config.toml carries a `#` comment above each key and those comments
survive programmatic edits.

