### PR TITLE
docs(config): document the layered config model + add change-config s…

### DIFF
--- a/.agent/skills/add-or-change-config.md
+++ b/.agent/skills/add-or-change-config.md
@@ -1,0 +1,137 @@
+---
+title: Add or change a configuration field
+status: current
+version: 0.1.0
+last_updated: 2026-05-30
+last_verified: 2026-05-30
+source_refs:
+  - crates/aura-core/src/config.rs
+  - crates/aura-core/src/config_schema.rs
+  - crates/aura/src/runtime.rs
+  - crates/aura/src/cli/config.rs
+  - docs/configuration.md
+owner: "@rfluid"
+tags: [skill, config, cli]
+---
+
+# Add or change a configuration field
+
+Use this skill when adding a new knob to `config.toml`, changing the type or
+allowed values of an existing field, or wiring a config value into the running
+app. Read [`docs/configuration.md`](../../docs/configuration.md) first — it
+documents the five config layers and the precedence rules this procedure keeps
+in sync. This skill is the *how-to-change-it*; that doc is the *what-it-is*.
+
+The cardinal rule: **the typed struct is the source of truth, the field registry
+mirrors it, and a test enforces they never drift.** If you add a struct field
+without a registry descriptor, `registry_covers_every_field` fails the build —
+that's by design, not an obstacle. Work *with* it.
+
+## Where each layer lives
+
+| Layer | File | You touch it when… |
+|---|---|---|
+| Typed struct | `crates/aura-core/src/config.rs` | always (the field itself) |
+| Field registry | `crates/aura-core/src/config_schema.rs` | always (describe + get/set) |
+| Runtime mirror | `crates/aura/src/runtime.rs` | the field must reach the tray loop *and* modal |
+| Consumer | `crates/aura/src/app.rs`, `main.rs`, … | the field actually does something |
+| CLI handler | `crates/aura/src/cli/config.rs` | almost never — it's registry-driven |
+| Docs | `docs/configuration.md`, `docs/cli.md`, `README.md` | always |
+
+The CLI (`describe` / `get` / `set` / `wizard` / `init` / `document`) and the
+`#`-commented `config.toml` template are **all driven by the registry** — you do
+not write per-command code for a new field. Add the descriptor and every surface
+updates for free.
+
+## Adding a new scalar field under `[display]` / `[update]`
+
+1. **Add the struct field** in `config.rs` (on `DisplayConfig` or
+   `UpdateConfig`). Give it a doc comment — it's the prose your registry
+   `description` will quote. Update that struct's `Default` impl. Use
+   `#[serde(default)]` on the field (or rely on the struct-level `#[serde(default)]`)
+   so old configs without the key still parse. Optional fields are `Option<T>`.
+
+2. **Add a `FieldDescriptor`** to `fields()` in `config_schema.rs`, in
+   template-emission order (`display.*` before `update.*`). Fill every field:
+   `key` (dotted), `type_label` (`string`/`string?`/`string[]`/`bool`/`u32?`),
+   `allowed` (`&[]` for free-form), `default`, `summary` (one line, also the
+   inline `#` comment), `description` (full prose), `example`.
+
+3. **Wire `get_value` and `set_value`** (same file) — add a `match` arm for the
+   new key in each. Reuse the parse helpers: `parse_enum`, `parse_bool`,
+   `parse_opt_u32`, `parse_opt_string`, `parse_list`. Constrained values must go
+   through `parse_enum` against the *same* `allowed` slice you put in the
+   descriptor.
+
+4. **Run the guards:**
+   ```bash
+   cargo test -p aura-core config_schema
+   ```
+   `registry_covers_every_field` proves the struct and registry agree;
+   `get_and_set_round_trip_every_descriptor` proves your `example` actually sets;
+   `render_commented_round_trips_*` proves the commented template still parses
+   back to the same config.
+
+5. **Consume the value.** A field that nothing reads is dead config. If only the
+   modal needs it, read `config.display.<field>` in `app.rs`. **If both the tray
+   poll loop (`main.rs`) and the modal need it**, mirror it through
+   `runtime.rs`: add a `static AtomicBool`/etc., an accessor, and a line in
+   `set_from_config`. Reapply any platform state there too (see the macOS
+   activation-policy precedent). This is what keeps the background loop from
+   drifting against a freshly-reloaded config.
+
+6. **Document it.** Add a row to the field-reference table in
+   `docs/configuration.md`, refresh that doc's `last_verified`, and update
+   `docs/cli.md` / `README.md` if the surface changed. The doc's
+   `registry_covers_every_field` note means the tables should always match
+   `config describe`.
+
+## Changing an existing field's allowed values or type
+
+- Update the `allowed` slice (or `type_label`) on the descriptor **and** the
+  matching `parse_enum`/parser call in `set_value` — they must list the same
+  set, or `set` will accept/reject inconsistently with what `describe` shows.
+- If you rename or remove a key, keep deserialization lenient: unrecognised
+  values should fall back to a sane default rather than failing the parse (see
+  how `anchor` treats the legacy `"auto"`). Never make an old on-disk config
+  fail to load.
+- Re-run the `config_schema` tests; fix the `example` if it no longer validates.
+
+## Adding a field to a repeatable table (`[[agents]]` / `[[plugins]]`)
+
+These are **not** `get`/`set` targets — they're managed via `aura agents` /
+`aura plugin` / `config edit`.
+
+1. Add the field to `AgentConfig` / `PluginConfig` in `config.rs` (`#[serde(default)]`
+   for backward compatibility).
+2. Add a `SectionField` to `agent_fields()` / `plugin_fields()` in
+   `config_schema.rs` so `describe` and the template header document it.
+3. Update the round-trip assertions in `render_commented_round_trips_populated`
+   to cover the new field.
+4. Document it in the relevant table in `docs/configuration.md`.
+
+## Smoke test
+
+```bash
+cargo run -p aura -- config describe                 # new field listed?
+cargo run -p aura -- config describe <key>           # full prose + current value
+cargo run -p aura -- config set <key> <value>        # validation + near-miss keys
+cargo run -p aura -- config get <key>
+cargo run -p aura -- config init --force             # regenerate; confirm the # comment
+cargo run -p aura -- config validate
+```
+
+For a runtime-mirrored field, also confirm the reload paths pick it up without a
+restart: edit the value, click the tray icon (re-open), and check the behaviour
+changed (config is reloaded on every open and on the modal Refresh button — see
+the reload-triggers section of the configuration doc).
+
+## Checklist
+
+- [ ] Struct field + doc comment + `Default` updated (`config.rs`)
+- [ ] `FieldDescriptor` / `SectionField` added (`config_schema.rs`)
+- [ ] `get_value` + `set_value` arms wired (scalars only)
+- [ ] `cargo test -p aura-core config_schema` green
+- [ ] Value actually consumed (and mirrored via `runtime.rs` if dual-surface)
+- [ ] `docs/configuration.md` table + `last_verified` updated; `cli.md` / `README.md` if needed
+- [ ] Smoke-tested via the `config` CLI

--- a/crates/aura-core/src/config.rs
+++ b/crates/aura-core/src/config.rs
@@ -131,24 +131,33 @@ pub struct DisplayConfig {
     /// edges. Default false: Aura behaves like a tray popup with a fixed
     /// width that auto-fits its content vertically.
     ///
-    /// Turning this on toggles three things together because they only make
-    /// sense as a set:
-    /// 1. `titlebar` is created instead of `None`, so the OS draws the
-    ///    standard chrome (and, on KDE / GNOME, the window menu items like
-    ///    "all desktops" / "always on top" come along for free — they're
-    ///    compositor-rendered, not drawn by Aura).
-    /// 2. `is_resizable` is set true and Wayland decorations are server-
-    ///    side so the compositor exposes resize edges.
-    /// 3. The content-fit auto-resize that runs on every layout pass is
-    ///    suppressed, otherwise it fights every drag.
+    /// Turning this on draws the OS title bar and its window-menu items (on
+    /// KDE / GNOME the "all desktops" / "always on top" entries come along for
+    /// free — they're compositor-rendered, not drawn by Aura).
+    ///
+    /// Chrome only controls the *title bar*. Whether the modal auto-resizes to
+    /// fit its content is a separate axis, see [`Self::auto_resize`].
     pub window_chrome: bool,
+    /// Whether the modal auto-resizes to fit its content height.
+    ///
+    /// On every layout pass a content-fit callback measures the rendered
+    /// content and grows / shrinks the window to match (capped at the screen
+    /// work area and [`Self::max_height`]). `None` (default) means "yes" — the
+    /// modal auto-fits. Set `false` for a fixed-size window.
+    ///
+    /// This is *not* about user drag-to-resize (the window manager owns that);
+    /// it only toggles Aura's own content-fit. Independent of
+    /// [`Self::window_chrome`]: the auto-fit behaves the same with or without
+    /// the native title bar.
+    #[serde(default)]
+    pub auto_resize: Option<bool>,
     /// Optional upper bound (in logical pixels) on the modal's auto-fit
     /// height. The content-fit callback already caps growth at the screen's
     /// available work area; this lets the user impose a tighter ceiling so
     /// the modal never grows past, say, 500 px even on a tall display.
     ///
     /// `None` (default) means "only the work-area cap applies".
-    /// Ignored when [`Self::window_chrome`] is true (auto-fit is off then).
+    /// Ignored when [`Self::auto_resize`] is false (no auto-fit to cap).
     #[serde(default)]
     pub max_height: Option<u32>,
     /// Swap the modal's user-facing copy for an aggressive / unhinged variant
@@ -179,6 +188,15 @@ fn default_anchor() -> String {
     }
 }
 
+impl DisplayConfig {
+    /// Effective auto-fit behaviour: `auto_resize` unset (`None`) means the
+    /// modal auto-resizes to fit its content height. `false` makes it a
+    /// fixed-size window. Applies whether or not [`Self::window_chrome`] is on.
+    pub fn auto_resize(&self) -> bool {
+        self.auto_resize.unwrap_or(true)
+    }
+}
+
 impl Default for DisplayConfig {
     fn default() -> Self {
         Self {
@@ -188,6 +206,7 @@ impl Default for DisplayConfig {
             show_in_app_switcher: false,
             dismiss_on_focus_loss: true,
             window_chrome: false,
+            auto_resize: None,
             max_height: None,
             goblin_mode: false,
         }

--- a/crates/aura-core/src/config_schema.rs
+++ b/crates/aura-core/src/config_schema.rs
@@ -123,13 +123,26 @@ pub fn fields() -> &'static [FieldDescriptor] {
             type_label: "bool",
             allowed: &["true", "false"],
             default: "false",
-            summary: "Show native window chrome (title bar + drag-to-resize).",
+            summary: "Show the native window title bar.",
             description: "Show the OS-native window chrome (title bar + minimize / maximize / \
-                close buttons) and let the user resize the modal by dragging its edges. \
-                Default false: Aura behaves like a tray popup with a fixed width that \
-                auto-fits its content vertically. Turning this on also enables resizing and \
-                suppresses the content-fit auto-resize (which would otherwise fight the drag).",
+                close buttons). Default false: Aura behaves like a tray popup with no title \
+                bar. This only controls the title bar — whether the modal auto-resizes to fit \
+                its content is the separate display.auto_resize knob.",
             example: "false",
+        },
+        FieldDescriptor {
+            key: "display.auto_resize",
+            type_label: "bool?",
+            allowed: &["true", "false"],
+            default: "unset (auto-fit)",
+            summary: "Auto-resize the modal to fit its content height.",
+            description: "Whether the modal auto-resizes to fit its content height. On every \
+                layout pass a content-fit callback grows / shrinks the window to match (capped \
+                at the screen work area and display.max_height). Unset (default) means auto-fit \
+                is on. Set false for a fixed-size window. This is not user drag-to-resize (the \
+                window manager owns that) — only Aura's content-fit. Independent of \
+                window_chrome, so the auto-fit works the same with or without the title bar.",
+            example: "true",
         },
         FieldDescriptor {
             key: "display.max_height",
@@ -328,6 +341,11 @@ pub fn get_value(cfg: &AppConfig, key: &str) -> Result<String, SchemaError> {
         "display.show_in_app_switcher" => cfg.display.show_in_app_switcher.to_string(),
         "display.dismiss_on_focus_loss" => cfg.display.dismiss_on_focus_loss.to_string(),
         "display.window_chrome" => cfg.display.window_chrome.to_string(),
+        "display.auto_resize" => cfg
+            .display
+            .auto_resize
+            .map(|b| b.to_string())
+            .unwrap_or_else(|| "(unset)".to_string()),
         "display.max_height" => cfg
             .display
             .max_height
@@ -360,6 +378,7 @@ pub fn set_value(cfg: &mut AppConfig, key: &str, raw: &str) -> Result<(), Schema
             cfg.display.dismiss_on_focus_loss = parse_bool(key, raw)?
         }
         "display.window_chrome" => cfg.display.window_chrome = parse_bool(key, raw)?,
+        "display.auto_resize" => cfg.display.auto_resize = parse_opt_bool(key, raw)?,
         "display.max_height" => cfg.display.max_height = parse_opt_u32(key, raw)?,
         "display.goblin_mode" => cfg.display.goblin_mode = parse_bool(key, raw)?,
         "update.dismissed_version" => cfg.update.dismissed_version = parse_opt_string(raw),
@@ -401,6 +420,13 @@ fn is_clear(raw: &str) -> bool {
         raw.to_ascii_lowercase().as_str(),
         "" | "none" | "null" | "unset"
     )
+}
+
+fn parse_opt_bool(key: &str, raw: &str) -> Result<Option<bool>, SchemaError> {
+    if is_clear(raw) {
+        return Ok(None);
+    }
+    parse_bool(key, raw).map(Some)
 }
 
 fn parse_opt_u32(key: &str, raw: &str) -> Result<Option<u32>, SchemaError> {
@@ -508,6 +534,7 @@ fn toml_rhs(cfg: &AppConfig, key: &str) -> Option<String> {
         "display.show_in_app_switcher" => cfg.display.show_in_app_switcher.to_string(),
         "display.dismiss_on_focus_loss" => cfg.display.dismiss_on_focus_loss.to_string(),
         "display.window_chrome" => cfg.display.window_chrome.to_string(),
+        "display.auto_resize" => return cfg.display.auto_resize.map(|b| b.to_string()),
         "display.max_height" => return cfg.display.max_height.map(|n| n.to_string()),
         "display.goblin_mode" => cfg.display.goblin_mode.to_string(),
         "update.dismissed_version" => return cfg.update.dismissed_version.as_deref().map(quote),
@@ -580,6 +607,7 @@ mod tests {
     /// (which serde omits from TOML) still appear when checking coverage.
     fn fully_populated() -> AppConfig {
         let mut cfg = AppConfig::default_config();
+        cfg.display.auto_resize = Some(false);
         cfg.display.max_height = Some(500);
         cfg.update.dismissed_version = Some("0.0.0".to_string());
         cfg
@@ -719,6 +747,7 @@ mod tests {
                 show_in_app_switcher: true,
                 dismiss_on_focus_loss: false,
                 window_chrome: true,
+                auto_resize: Some(false),
                 max_height: Some(500),
                 goblin_mode: true,
             },

--- a/crates/aura/src/app.rs
+++ b/crates/aura/src/app.rs
@@ -655,10 +655,11 @@ impl Render for AuraView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let last_height = self.last_window_height.clone();
         let body_scroll = self.body_scroll.clone();
-        // When window_chrome is on, the OS draws a title bar and the user can
-        // drag the edges — so suppress the content-fit auto-resize that would
-        // otherwise snap the height back every layout pass.
-        let auto_fit = !self.config.display.window_chrome;
+        // `display.auto_resize` governs the content-fit auto-resize that grows /
+        // shrinks the window to fit its content on every layout pass. It is
+        // independent of `window_chrome`, so the auto-fit works the same with
+        // or without native chrome. Default on (see `DisplayConfig::auto_resize`).
+        let auto_fit = self.config.display.auto_resize();
         let user_max_height = self.config.display.max_height;
         // How the modal re-anchors after the auto-fit resize (see
         // `placement::Anchor`). Only `Bottom` triggers an active move.

--- a/crates/aura/src/main.rs
+++ b/crates/aura/src/main.rs
@@ -437,14 +437,13 @@ fn toggle_window(
     } else {
         WindowKind::PopUp
     };
-    // `display.window_chrome` swaps the modal between two modes:
-    //   false (default): chromeless tray-popup, fixed width, height auto-fits
-    //     content (see app.rs::on_children_prepainted). is_resizable is
-    //     forced false because there is no visible edge to grab anyway.
-    //   true: native OS chrome (title bar + min/max/close), user-resizable.
-    //     window_decorations: Server asks Wayland compositors to draw SSD;
-    //     the auto-fit callback in app.rs is suppressed so user-dragged
-    //     sizes stick.
+    // `display.window_chrome` controls only the native title bar:
+    //   false (default): chromeless tray-popup, fixed width.
+    //   true: native OS chrome (title bar + min/max/close). window_decorations:
+    //     Server asks Wayland compositors to draw SSD.
+    // Whether the modal auto-fits its content height is a separate axis,
+    // governed by `display.auto_resize` in app.rs (see on_children_prepainted) —
+    // independent of chrome, so the auto-fit works in both modes.
     let (titlebar, is_resizable, window_decorations) = if config.display.window_chrome {
         (
             Some(TitlebarOptions::default()),
@@ -475,8 +474,14 @@ fn toggle_window(
         ..Default::default()
     };
 
+    // Cloak (Windows) hides the first-frame flash that only happens when the
+    // auto-fit step shrinks the window from its open-time MODAL_H to the
+    // content height. So it must track `auto_resize` (the same flag that gates
+    // the auto-fit callback / uncloak in app.rs) — NOT `window_chrome`. Tying
+    // it to chrome would leave a chromeless + fixed-size window (auto_resize =
+    // false) cloaked forever, since no uncloak step ever runs.
     #[cfg(target_os = "windows")]
-    let cloak = !config.display.window_chrome;
+    let cloak = config.display.auto_resize();
 
     match cx.open_window(opts, |_window, cx| {
         cx.new(|cx| AuraView::new(config, config_path, state, cx))
@@ -502,9 +507,9 @@ fn toggle_window(
                 // on the second frame after the resize, showing the window at
                 // the correct size.
                 //
-                // Skipped when `window_chrome` is on: there is no auto-shrink
-                // step in that mode, so cloaking would leave the window
-                // invisible forever.
+                // Skipped when `auto_resize` is off (`cloak` is false): there
+                // is no auto-shrink step then, so cloaking would leave the
+                // window invisible forever.
                 let _ = handle.update(cx, |_, window, _| {
                     if cloak {
                         win32_set_cloak(window, true);

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,8 +144,9 @@ are not `get`/`set` targets. The legacy `aura setup-config` is a hidden alias fo
 | `plugin_order` | string[] | — | `[]` | Display order for plugin pills (comma-separated names on `set`). |
 | `show_in_app_switcher` | bool | `true` \| `false` | `false` | Show the modal in Alt+Tab / Cmd+Tab / dock surfaces. |
 | `dismiss_on_focus_loss` | bool | `true` \| `false` | `true` | Auto-close the modal when it loses focus. |
-| `window_chrome` | bool | `true` \| `false` | `false` | Native window chrome + drag-to-resize (disables auto-fit). |
-| `max_height` | u32? | — | unset | Upper bound (logical px) on auto-fit height; ignored when `window_chrome = true`. |
+| `window_chrome` | bool | `true` \| `false` | `false` | Show the native window title bar (independent of `auto_resize`). |
+| `auto_resize` | bool? | `true` \| `false` | unset (auto-fit) | Auto-resize the modal to fit its content height. `false` = fixed-size. Works with or without chrome. |
+| `max_height` | u32? | — | unset | Upper bound (logical px) on auto-fit height; ignored when `auto_resize` is false. |
 | `goblin_mode` | bool | `true` \| `false` | `false` | Swap UI copy for the aggressive "Goblin Mode" variant. |
 
 ### `[update]`
@@ -227,13 +228,18 @@ plugin_order = ["Hello", "RTK Gains"]
 # Default is per-OS and written at install (see "Modal anchoring" below).
 anchor = "bottom"
 
-# Native window chrome (title bar + drag-to-resize). Default false — Aura is a
-# fixed-width tray popup that auto-fits its height. Turning this on disables the
-# auto-fit and puts the modal in the taskbar / alt-tab list.
+# Show the native window title bar. Default false — Aura is a chromeless tray
+# popup. Turning this on also puts the modal in the taskbar / alt-tab list.
+# Independent of `auto_resize`.
 window_chrome = false
 
+# Auto-resize the modal to fit its content height. Unset (default) = auto-fit on.
+# Set false for a fixed-size modal. Works the same with or without window_chrome.
+# (This is not user drag-to-resize — the window manager owns that.)
+# auto_resize = false
+
 # Optional upper bound (logical px) on auto-fit height. Already capped at the
-# screen work area; this is a tighter ceiling. Ignored when window_chrome = true.
+# screen work area; this is a tighter ceiling. Ignored when auto_resize = false.
 # max_height = 500
 
 # Auto-close the modal when it loses focus. Default true (tray-popup behaviour);

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,47 +1,195 @@
 ---
 title: Configuration
-status: draft
-version: 0.1.1
-last_updated: 2026-05-24
-last_verified: 2026-05-24
-source_refs: ["crates/aura-core/src/config.rs", "crates/aura/src/cli/config.rs"]
+status: current
+version: 0.2.0
+last_updated: 2026-05-30
+last_verified: 2026-05-30
+source_refs:
+  - crates/aura-core/src/config.rs
+  - crates/aura-core/src/config_schema.rs
+  - crates/aura-core/src/state.rs
+  - crates/aura/src/cli/config.rs
+  - crates/aura/src/runtime.rs
+  - crates/aura/src/main.rs
+  - crates/aura/src/app.rs
 owner: "@rfluid"
 tags: [configuration, docs]
 ---
 
 # Configuration
 
-## File location
+Aura's configuration is layered: typed Rust structs are the source of truth, a
+field registry documents and validates them, three on-disk files persist the
+values, and a small runtime layer keeps the running tray app and modal in sync
+as those files change. This page documents every field and how the layers fit
+together. To **add or change** a config field as a developer, see
+[`.agent/skills/add-or-change-config.md`](../.agent/skills/add-or-change-config.md),
+which builds on this reference.
 
-`~/.config/aura/config.toml`
+## File locations
 
-Aura creates a default config on first run if none exists.
+| File | Path | What it holds | Edited by |
+|---|---|---|---|
+| Config | `~/.config/aura/config.toml` | Agents, plugins, `[display]`, `[update]` | You (CLI / editor) |
+| Theme | `~/.config/aura/theme.toml` | Color / font / spinner overrides | You (CLI / editor) |
+| State | `~/.local/share/aura/state.json` | Active profile selection | Aura (do not hand-edit) |
+| Plugins dir | `~/.config/aura/plugins/` | Auto-discovered plugin binaries | `aura plugin add` |
 
-For scripted access, prefer the CLI:
+Paths follow the XDG base-dir spec via the `dirs` crate, so the exact location
+differs on macOS / Windows — always resolve it with `aura config path`. Aura
+writes a fully-commented default `config.toml` on first run if none exists.
+
+## The runtime model — config in layers
+
+Config flows through five layers, top (authoring) to bottom (consumption):
+
+1. **Typed structs** — `crates/aura-core/src/config.rs`. `AppConfig` is the
+   root (`agents`, `plugins`, `display`, `update`); each sub-struct derives
+   `Serialize`/`Deserialize` and a `Default`, so the whole tree round-trips
+   through TOML and an empty/partial file still parses (missing fields fall back
+   to `Default`). This is the **source of truth** — the shape of a config is
+   whatever these structs say it is.
+
+2. **Field registry / schema** — `crates/aura-core/src/config_schema.rs`. A
+   flat list of `FieldDescriptor`s (one per settable scalar under `[display]` /
+   `[update]`) plus `SectionField`s describing the repeatable `[[agents]]` /
+   `[[plugins]]` tables. This registry powers everything self-documenting:
+   `config describe`, `get`/`set` validation, the `wizard`, and the
+   `#`-commented `config.toml` template (`render_commented`). A unit test
+   (`registry_covers_every_field`) serializes a default config and asserts every
+   leaf key has a descriptor — so the docs **cannot drift** from the structs
+   without breaking the build.
+
+3. **Persistence (disk)** — the four files above. `config.toml` is always
+   written through `render_commented`, so every key carries a `#` comment lifted
+   from the registry; those comments survive programmatic edits (`set`, `wizard`,
+   `setup`).
+
+4. **Load + merge** — `AppConfig::load` reads the file (writing defaults if
+   absent); `load_with_discovery` additionally merges executable plugins found in
+   the plugins dir (config-listed entries win on name collision) and applies
+   `display.plugin_order`; `run_setup` detects installed agents and merges new
+   ones without disturbing existing edits.
+
+5. **Runtime mirror** — `crates/aura/src/runtime.rs`. The tray poll loop in
+   `main.rs` and the modal's async refresh task in `app.rs` each reload the
+   config independently. To stop them drifting, a handful of `[display]` fields
+   are mirrored into process atomics via `runtime::set_from_config`, and any
+   platform state they drive (e.g. the macOS NSApp activation policy) is
+   reapplied there. Add an atomic + accessor here when a new `[display]` knob
+   must be visible to *both* the background loop and the modal.
+
+### Reload triggers (hot reload)
+
+Most edits take effect **without a restart**. `set_from_config` is called, and
+the config (and `theme.toml`) reloaded, at three moments:
+
+- **Startup** — `main.rs` loads once before launching GPUI.
+- **Every tray click** — the `Show` arm reloads via `load_with_discovery`, so a
+  config edit (or a freshly-dropped plugin binary) is live on the next open.
+- **Refresh button** — `app::do_refresh` reloads config + theme on a background
+  thread; a malformed `theme.toml` logs a warning and falls back to defaults
+  rather than blanking the UI.
+
+A failed reload falls back to the last good in-memory snapshot, so a transient
+I/O error never breaks the toggle.
+
+### Precedence
+
+- **Scalar fields:** struct `Default` (incl. the per-OS `default_anchor`) →
+  value in `config.toml`.
+- **Plugins:** a `[[plugins]]` block in `config.toml` overrides an
+  auto-discovered binary of the same `name` (case-insensitive) — that's how you
+  pin a color/icon onto a discovered plugin.
+- **Agent accent color:** `[agents."<name>"].accent` in `theme.toml` → `[[agents]]
+  color` in `config.toml` → per-kind brand default → luminance fallback (see
+  [Themes](#themes)).
+
+## CLI surface
+
+Prefer the CLI over editing the file by hand — it validates values, suggests
+near-miss keys, and keeps the inline docs intact.
 
 ```text
-aura config path        # print resolved path
-aura config show        # dump current config (--format text|json)
-aura config edit        # open in $EDITOR (seeds defaults if missing)
-aura config validate    # parse-check
-aura config setup       # re-detect installed agents (alias: setup-config)
+aura config setup              # detect installed agents, write/update config.toml
+aura config path               # print resolved config path
+aura config show               # print loaded config (--format text|json)
+aura config describe [<key>]   # list every field (type/default/docs), or explain one
+                               #   (--format json emits the full schema)
+aura config get <key>          # print a single field's current value
+aura config set <key> <value>  # validate and set one field (e.g. set display.anchor top)
+aura config wizard             # walk every field interactively; blank keeps current
+aura config init [--force]     # write a fresh, fully-commented config.toml
+aura config document           # rewrite the existing config in place with inline docs
+aura config edit               # open in $EDITOR (creates defaults if missing)
+aura config validate           # parse-check
 ```
 
-See `docs/cli.md` for the full subcommand surface.
+Keys are dotted paths into `[display]` / `[update]`, e.g. `display.anchor`,
+`display.max_height`, `update.dismiss_all`. `set` rejects bad enums/booleans and
+suggests near-miss keys; pass `none` (or empty) to clear an optional field. The
+repeatable `[[agents]]` / `[[plugins]]` tables are *documented* by `describe`
+but **edited** via `aura config edit`, `aura agents`, or `aura plugin` — they
+are not `get`/`set` targets. The legacy `aura setup-config` is a hidden alias for
+`aura config setup`. See [`docs/cli.md`](cli.md) for the full surface.
+
+## Field reference
+
+### `[display]`
+
+| Key | Type | Allowed | Default | Summary |
+|---|---|---|---|---|
+| `default_period` | string | `all` \| `7d` \| `30d` | `all` | Usage period tab selected on open. |
+| `anchor` | string | `none` \| `bottom` \| `top` | `none` (macOS/Linux), `bottom` (Windows) | How the modal anchors as it auto-fits height. |
+| `plugin_order` | string[] | — | `[]` | Display order for plugin pills (comma-separated names on `set`). |
+| `show_in_app_switcher` | bool | `true` \| `false` | `false` | Show the modal in Alt+Tab / Cmd+Tab / dock surfaces. |
+| `dismiss_on_focus_loss` | bool | `true` \| `false` | `true` | Auto-close the modal when it loses focus. |
+| `window_chrome` | bool | `true` \| `false` | `false` | Native window chrome + drag-to-resize (disables auto-fit). |
+| `max_height` | u32? | — | unset | Upper bound (logical px) on auto-fit height; ignored when `window_chrome = true`. |
+| `goblin_mode` | bool | `true` \| `false` | `false` | Swap UI copy for the aggressive "Goblin Mode" variant. |
+
+### `[update]`
+
+Controls the "Update available" header button.
+
+| Key | Type | Allowed | Default | Summary |
+|---|---|---|---|---|
+| `dismissed_version` | string? | — | unset | Last release dismissed via the button's ×; a newer release re-shows it. |
+| `dismiss_all` | bool | `true` \| `false` | `false` | Master mute: never render the button or fire the GitHub check. |
+
+### `[[agents]]` (repeatable)
+
+| Field | Type | Allowed | Summary |
+|---|---|---|---|
+| `name` | string | — | Display name for this agent profile. |
+| `kind` | string | `claude-code` \| `codex` \| `gemini` | Which agent this profile reads. |
+| `config_path` | string? | — | Agent config dir; defaults to `~/.claude`, `~/.codex`, `~/.gemini` per kind. |
+| `color` | string? | — | Accent color override, hex like `#rrggbb` or `#rgb`. |
+
+### `[[plugins]]` (repeatable)
+
+| Field | Type | Allowed | Summary |
+|---|---|---|---|
+| `name` | string | — | Display name for the plugin pill. |
+| `command` | string | — | Binary name on `$PATH` or absolute path. |
+| `color` | string? | — | Accent color override, hex like `#rrggbb` or `#rgb`. |
+| `icon` | string? | — | SVG icon: embedded asset name, absolute path, or `~/` path. |
 
 ## Full example
 
 ```toml
-# Aura configuration
+# Aura configuration.
+# Run `aura config describe` for full field docs, or
+# `aura config set <key> <value>` to change a value from the CLI.
 
 # ── Agent profiles ───────────────────────────────────────────────────────────
-# Define as many profiles as you need. The active profile is tracked in state,
-# not here — switching profiles in the UI does not touch this file.
+# Define as many profiles as you need. The active profile is tracked in state
+# (state.json), not here — switching profiles in the UI does not touch this file.
 
 [[agents]]
 name = "Claude Code (Personal)"
 kind = "claude-code"
-# Path to the Claude Code config directory. Defaults to ~/.claude if omitted.
+# Path to the agent's config directory. Defaults to ~/.claude when omitted.
 config_path = "~/.claude"
 
 [[agents]]
@@ -52,79 +200,62 @@ config_path = "~/.claude-enterprise"
 [[agents]]
 name = "Codex"
 kind = "codex"
-# Path to the Codex config directory. Defaults to ~/.codex if omitted.
 config_path = "~/.codex"
 
 # ── Plugins ──────────────────────────────────────────────────────────────────
-#
-# Plugins are typically installed via `aura plugin add <path>`, which writes
-# the binary into ~/.config/aura/plugins/ and registers it via auto-discovery
-# — no [[plugins]] block needed. Use the inline form below only for plugins
-# that live outside the user plugins dir (e.g. system-wide binaries on $PATH).
+# Plugins are usually installed via `aura plugin add <path>`, which drops the
+# binary into ~/.config/aura/plugins/ and registers it via auto-discovery — no
+# [[plugins]] block needed. Use the inline form below only for plugins outside
+# the user plugins dir, or to pin a color/icon onto a discovered plugin (a block
+# with the same name wins over discovery).
 
 [[plugins]]
 name = "RTK Gains"
-# Binary on $PATH or absolute path
 command = "aura-plugin-rtk"
 
 # ── Display ──────────────────────────────────────────────────────────────────
 
 [display]
-# Which usage period to show by default when opening the modal
-# Options: "today" | "this_month" | "all_time"
-default_period = "today"
+# Which usage period tab is selected on open: "all" | "7d" | "30d".
+default_period = "all"
 
-# Optional explicit ordering for the plugin pill row. Plugins named here
-# render in this order; anything not named keeps its natural order
-# (config-then-discovered-alphabetical) and appends afterwards. Match is
-# case-insensitive against each plugin's display `name`. Omit or set to
-# [] to keep the default ordering.
+# Explicit ordering for the plugin pill row. Named plugins render first in this
+# order (case-insensitive match on `name`); the rest keep their natural order.
 plugin_order = ["Hello", "RTK Gains"]
 
-# How the modal anchors as it auto-fits its content height.
-# Options:
-#   "none"   — open at the platform's natural tray corner and grow downward
-#              from there; never reposition after a resize. Safe on Wayland,
-#              where the compositor owns window placement.
-#   "bottom" — pin the bottom edge above a bottom taskbar so the modal grows
-#              *upward* (the tray-popup feel next to a bottom tray). Needs an
-#              active window move after each resize: supported on Windows,
-#              macOS, and Linux/X11. On Linux/Wayland it only applies at open
-#              (the compositor owns placement — see note below).
-#   "top"    — pin the top edge just below a top panel / menu bar and grow
-#              downward.
-# Default is OS-specific and written for you at install: "bottom" on Windows
-# (bottom taskbar), "none" on macOS and Linux. Unrecognised values (including
-# the legacy "auto") fall back to the per-OS default.
+# How the modal anchors as it auto-fits height: "none" | "bottom" | "top".
+# Default is per-OS and written at install (see "Modal anchoring" below).
 anchor = "bottom"
 
-# Show OS-native window chrome (title bar + min/max/close) and let the user
-# resize the modal by dragging its edges. Default false — Aura behaves like a
-# fixed-width tray popup that auto-fits its height. Turning this on also
-# disables the auto-fit (so a dragged size sticks) and puts the modal in the
-# taskbar / alt-tab list.
+# Native window chrome (title bar + drag-to-resize). Default false — Aura is a
+# fixed-width tray popup that auto-fits its height. Turning this on disables the
+# auto-fit and puts the modal in the taskbar / alt-tab list.
 window_chrome = false
 
-# Optional upper bound (logical px) on the auto-fit height. The modal is
-# already capped at the screen's available work area; this imposes a tighter
-# ceiling. Omit (or leave unset) for "only the work-area cap applies".
-# Ignored when window_chrome = true (auto-fit is off then).
+# Optional upper bound (logical px) on auto-fit height. Already capped at the
+# screen work area; this is a tighter ceiling. Ignored when window_chrome = true.
 # max_height = 500
 
-# Auto-close the modal when it loses focus (click outside, switch app).
-# Default true — matches typical menu-bar / tray-popup behaviour. Set
-# to false to make the modal sticky (only the tray icon closes it),
-# which is handy when copy-pasting from the modal into another window.
+# Auto-close the modal when it loses focus. Default true (tray-popup behaviour);
+# set false to keep it open until the tray icon is clicked again.
 dismiss_on_focus_loss = true
 
-# Appear in the OS's "where are my windows" surfaces:
-# - macOS:   Cmd+Tab app switcher + Dock (NSApp activation policy)
-# - Windows: Alt+Tab + taskbar (WS_EX_APPWINDOW vs WS_EX_TOOLWINDOW)
-# - Linux:   panel / window switcher (WindowKind::Normal vs PopUp)
-# Default false — Aura runs as a tray-only indicator. Reapplies on the
-# next refresh (modal Refresh button) or modal open, so a config edit
-# takes effect without restarting the service.
+# Appear in Alt+Tab / Cmd+Tab / dock / panel surfaces. Default false (tray-only).
+# Reapplies on the next refresh or open — no restart needed.
 show_in_app_switcher = false
+
+# Swap UI copy for the aggressive "Goblin Mode" variant. Default false.
+goblin_mode = false
+
+# ── Update ───────────────────────────────────────────────────────────────────
+
+[update]
+# Last release version dismissed via the update button's × (bare semver). A
+# newer release re-shows the button. Omit for "never dismissed".
+# dismissed_version = "0.1.18"
+
+# Master mute: never render the update button, never call GitHub. Default false.
+dismiss_all = false
 ```
 
 ### Modal anchoring (`anchor`)
@@ -141,7 +272,8 @@ content height:
 The right default is written to your config at install time based on your OS,
 so most people never need to set this. Change it if your taskbar/panel is
 somewhere other than your platform's default (e.g. a Linux desktop with a
-**top** panel → `anchor = "top"`).
+**top** panel → `anchor = "top"`). Unrecognised values (including the legacy
+`"auto"`) fall back to the per-OS default.
 
 **Linux note:** on **X11**, `anchor = "bottom"` repositions live — after each
 resize Aura asks the window manager to move the modal via an EWMH
@@ -161,19 +293,26 @@ Linux top-panel setup approximates by sitting at the very top of the display.
 
 ## Agent kinds
 
-| `kind` | Description | Config fields |
+| `kind` | Description | Default `config_path` |
 |---|---|---|
-| `claude-code` | Claude Code CLI agent | `config_path` (path to the dir containing `stats-cache.json`; defaults to `~/.claude`) |
-| `codex` | OpenAI Codex CLI | `config_path` (path to the dir containing `sessions/`; defaults to `~/.codex`) |
+| `claude-code` | Claude Code CLI agent | `~/.claude` (dir containing `stats-cache.json` / `projects/`) |
+| `codex` | OpenAI Codex CLI | `~/.codex` (dir containing `sessions/`) |
+| `gemini` | Gemini CLI | `~/.gemini` |
+
+A leading `~` in `config_path` is expanded to the user's home directory.
 
 ## State file
 
-Aura writes the active profile selection to `~/.local/share/aura/state.json`. This file is managed automatically — do not edit by hand.
+Aura writes the active profile selection to
+`~/.local/share/aura/state.json`. This file is managed automatically —
+`toggle_window` reloads it each time the modal opens, so a profile change made
+in one session is visible the next time you click the tray icon. **Do not edit
+by hand**; use `aura state set-profile <name>` (validated against
+`config.agents`).
 
 ```json
 {
-  "active_profile": "Claude Code (Personal)",
-  "last_updated": "2026-05-21T14:30:00Z"
+  "active_profile": "Claude Code (Personal)"
 }
 ```
 
@@ -207,7 +346,7 @@ interval_ms = 80
 accent = "#d97757"
 ```
 
-### Precedence
+### Color precedence
 
 For an agent's accent color, the first match wins:
 
@@ -225,4 +364,4 @@ The refresh button in the header reloads `theme.toml` alongside `config.toml`
 — no restart required. A malformed file logs a warning and falls back to the
 built-in defaults rather than blanking the UI.
 
-See `.design/customization.md` for the full schema reference.
+See `.design/customization.md` for the full theme schema reference.


### PR DESCRIPTION
…kill

Rewrite docs/configuration.md around the five config layers (typed structs → field registry → disk → load/merge → runtime atomics mirror), with reload triggers and precedence rules. Add the missing [update] table, goblin_mode, agent/plugin color, plugin icon, and the gemini kind; complete field-reference tables matching the registry. Fix default_period allowed values (all/7d/30d, not today/this_month/all_time).

Add .agent/skills/add-or-change-config.md: a developer how-to for adding or changing a config field, keyed to the anti-drift registry test and the runtime-mirror wiring, referencing the configuration doc.