### PR TITLE
feat(plugin): skip period re-runs for period-insensitive plugins

### DIFF
--- a/crates/aura-core/src/plugin/mod.rs
+++ b/crates/aura-core/src/plugin/mod.rs
@@ -110,6 +110,15 @@ impl PluginPanel {
     pub fn section(&self, id: &str) -> Option<&PluginSection> {
         self.sections.iter().find(|s| s.id == id)
     }
+
+    /// Whether any section filters by the active period. Error panels and
+    /// panels with no sections return `true` so the host re-runs them on
+    /// period change (retry rather than cache a failure).
+    pub fn uses_period(&self) -> bool {
+        self.error.is_some()
+            || self.sections.is_empty()
+            || self.sections.iter().any(|s| s.uses_period)
+    }
 }
 
 // ── Legacy wire format (single flat panel) ────────────────────────────────────
@@ -146,5 +155,55 @@ impl From<LegacyPluginPanel> for PluginPanel {
             }],
             error: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn section(uses_period: bool) -> PluginSection {
+        PluginSection {
+            id: "s".to_string(),
+            label: "S".to_string(),
+            uses_period,
+            content: PluginContent::default(),
+        }
+    }
+
+    #[test]
+    fn uses_period_true_for_error_panel() {
+        let panel = PluginPanel::from_error("t", "boom");
+        assert!(panel.uses_period());
+    }
+
+    #[test]
+    fn uses_period_true_for_empty_sections() {
+        let panel = PluginPanel {
+            title: "t".to_string(),
+            sections: Vec::new(),
+            error: None,
+        };
+        assert!(panel.uses_period());
+    }
+
+    #[test]
+    fn uses_period_false_when_no_section_uses_it() {
+        let panel = PluginPanel {
+            title: "t".to_string(),
+            sections: vec![section(false), section(false)],
+            error: None,
+        };
+        assert!(!panel.uses_period());
+    }
+
+    #[test]
+    fn uses_period_true_when_any_section_uses_it() {
+        let panel = PluginPanel {
+            title: "t".to_string(),
+            sections: vec![section(false), section(true)],
+            error: None,
+        };
+        assert!(panel.uses_period());
     }
 }

--- a/crates/aura/src/app.rs
+++ b/crates/aura/src/app.rs
@@ -244,6 +244,17 @@ impl AuraView {
     /// background executor. The result is applied via `apply_refresh_result`
     /// back on the foreground thread.
     fn refresh(&mut self, cx: &mut Context<Self>) {
+        self.refresh_inner(cx, false);
+    }
+
+    /// Like [`Self::refresh`], but plugins whose last panel doesn't filter by
+    /// period keep their cached output instead of being re-spawned. Used when
+    /// only the active period changed — their data can't have changed.
+    fn refresh_for_period_change(&mut self, cx: &mut Context<Self>) {
+        self.refresh_inner(cx, true);
+    }
+
+    fn refresh_inner(&mut self, cx: &mut Context<Self>, period_only: bool) {
         if self.is_loading {
             // A refresh is already in flight; don't double-spawn.
             return;
@@ -257,11 +268,18 @@ impl AuraView {
         let theme_path = self.theme_path.clone();
         let active_profile = self.active_profile.clone();
         let period = self.active_period;
+        let cached_panels = if period_only {
+            self.plugin_panels.clone()
+        } else {
+            Vec::new()
+        };
 
         cx.spawn(async move |this, cx| {
             let result = cx
                 .background_executor()
-                .spawn(async move { do_refresh(config_path, theme_path, active_profile, period) })
+                .spawn(async move {
+                    do_refresh(config_path, theme_path, active_profile, period, cached_panels)
+                })
                 .await;
 
             this.update(cx, |view, cx| {
@@ -345,11 +363,23 @@ impl AuraView {
 /// thread can keep rendering the spinner. Errors are bundled into the
 /// returned `RefreshResult` rather than returned via `Result` so partial
 /// success (e.g. quota OK but snapshot failed) still surfaces.
+/// Cached panel for `name`, if its previous run proved the plugin is
+/// period-insensitive (no section sets `uses_period`). `None` means the
+/// plugin must be (re-)run — including error panels and unknown plugins.
+fn reusable_panel<'a>(cached: &'a [(String, PluginPanel)], name: &str) -> Option<&'a PluginPanel> {
+    cached
+        .iter()
+        .find(|(n, _)| n == name)
+        .map(|(_, p)| p)
+        .filter(|p| !p.uses_period())
+}
+
 fn do_refresh(
     config_path: PathBuf,
     theme_path: PathBuf,
     active_profile: String,
     period: Period,
+    cached_panels: Vec<(String, PluginPanel)>,
 ) -> RefreshResult {
     // Reload theme alongside the config so an edit to either file takes
     // effect on the same "Refresh" click (see .design/customization.md
@@ -433,10 +463,18 @@ fn do_refresh(
     let forecast = quota.as_ref().map(|q| forecast::forecast(q, Utc::now()));
 
     // Plugins: each runs as a subprocess with `--period` passed through.
+    // On a period-only refresh, plugins whose previous panel proved they
+    // don't filter by period keep that cached panel instead of re-spawning.
     let plugin_panels = config
         .plugins
         .iter()
-        .map(|p| (p.name.clone(), PluginRunner::run_with_period(p, period)))
+        .map(|p| {
+            let panel = match reusable_panel(&cached_panels, &p.name) {
+                Some(panel) => panel.clone(),
+                None => PluginRunner::run_with_period(p, period),
+            };
+            (p.name.clone(), panel)
+        })
         .collect();
 
     RefreshResult {
@@ -508,7 +546,7 @@ impl AuraView {
     fn set_period(&mut self, period: Period, cx: &mut Context<Self>) {
         if self.active_period != period {
             self.active_period = period;
-            self.refresh(cx);
+            self.refresh_for_period_change(cx);
         }
     }
 
@@ -2542,5 +2580,42 @@ mod tests {
     fn shows_when_never_dismissed() {
         let cfg = UpdateConfig::default();
         assert!(should_show_update_button(Some(&info("0.1.18")), &cfg));
+    }
+
+    fn panel(uses_period: bool) -> PluginPanel {
+        PluginPanel {
+            title: "t".to_string(),
+            sections: vec![PluginSection {
+                id: "s".to_string(),
+                label: "S".to_string(),
+                uses_period,
+                content: PluginContent::default(),
+            }],
+            error: None,
+        }
+    }
+
+    #[test]
+    fn reusable_panel_returns_period_insensitive_cache() {
+        let cached = vec![("RTK".to_string(), panel(false))];
+        assert!(reusable_panel(&cached, "RTK").is_some());
+    }
+
+    #[test]
+    fn reusable_panel_skips_period_using_cache() {
+        let cached = vec![("Hello".to_string(), panel(true))];
+        assert!(reusable_panel(&cached, "Hello").is_none());
+    }
+
+    #[test]
+    fn reusable_panel_skips_error_cache() {
+        let cached = vec![("RTK".to_string(), PluginPanel::from_error("t", "boom"))];
+        assert!(reusable_panel(&cached, "RTK").is_none());
+    }
+
+    #[test]
+    fn reusable_panel_skips_unknown_plugin() {
+        let cached = vec![("RTK".to_string(), panel(false))];
+        assert!(reusable_panel(&cached, "New Plugin").is_none());
     }
 }

--- a/crates/aura/src/app.rs
+++ b/crates/aura/src/app.rs
@@ -278,7 +278,13 @@ impl AuraView {
             let result = cx
                 .background_executor()
                 .spawn(async move {
-                    do_refresh(config_path, theme_path, active_profile, period, cached_panels)
+                    do_refresh(
+                        config_path,
+                        theme_path,
+                        active_profile,
+                        period,
+                        cached_panels,
+                    )
                 })
                 .await;
 

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -39,6 +39,10 @@ For the broader plugin-system rationale, see
 - The host always passes `--period`. Honour it if your data has a time
   dimension; otherwise mark the section as `uses_period = false` (see
   below) and the modal will hide the period pill row.
+- If **no** section in your panel sets `uses_period = true`, the host
+  reuses your previous output when the user switches periods instead of
+  re-invoking the binary (a manual refresh still re-runs everything).
+  Don't rely on being called once per period change.
 - Stdout must be a single UTF-8 JSON object. Stderr is captured and
   surfaced as the error message on non-zero exit.
 - The host enforces a **500 ms** budget per invocation. Cache or

--- a/plugins/rtk-gains/src/main.rs
+++ b/plugins/rtk-gains/src/main.rs
@@ -185,8 +185,9 @@ fn emit_error(msg: String) {
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 fn main() {
-    // Plugin protocol passes `--period all|7d|30d` (currently unused — `rtk gain`
-    // is always all-time today, but we accept the arg so the harness is happy).
+    // Plugin protocol passes `--period all|7d|30d`, but `rtk gain` is always
+    // all-time today, so every section is marked `uses_period: false` — the
+    // host hides the period pills and skips re-running us on period switches.
     let _args: Vec<String> = std::env::args().collect();
 
     let output = match Command::new("rtk")
@@ -403,7 +404,7 @@ fn overview_section(parsed: &RtkOutput) -> PluginSection {
     PluginSection {
         id: "overview".to_string(),
         label: "Overview".to_string(),
-        uses_period: true,
+        uses_period: false,
         content: PluginContent::Lines {
             lines: vec![
                 PluginLine {
@@ -498,7 +499,7 @@ fn by_command_section(parsed: &RtkOutput) -> PluginSection {
     PluginSection {
         id: "by-command".to_string(),
         label: "By Command".to_string(),
-        uses_period: true,
+        uses_period: false,
         content: PluginContent::Table {
             headers: vec![
                 "#".to_string(),


### PR DESCRIPTION
Plugins whose panel has no `uses_period` section (e.g. RTK Gains, whose
`rtk gain` data is always all-time) now keep their cached output when
only the active period changes, instead of being re-spawned on every
switch. The RTK plugin marks both its sections `uses_period: false`, so
the existing UI logic also hides the period pills on its tab.
